### PR TITLE
Mempool and Consensus only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,196 +2,196 @@
 resolver = "2"
 
 members = [
-    "api",
-    "api/openapi-spec-generator",
-    "api/test-context",
-    "api/types",
+    # "api",
+    # "api/openapi-spec-generator",
+    # "api/test-context",
+    # "api/types",
     "aptos-move/aptos-abstract-gas-usage",
     "aptos-move/aptos-aggregator",
-    "aptos-move/aptos-debugger",
-    "aptos-move/aptos-e2e-comparison-testing",
+    # "aptos-move/aptos-debugger",
+    # "aptos-move/aptos-e2e-comparison-testing",
     "aptos-move/aptos-gas-algebra",
-    "aptos-move/aptos-gas-calibration",
+    # "aptos-move/aptos-gas-calibration",
     "aptos-move/aptos-gas-meter",
     "aptos-move/aptos-gas-profiling",
     "aptos-move/aptos-gas-schedule",
     "aptos-move/aptos-gas-schedule-updator",
     "aptos-move/aptos-memory-usage-tracker",
     "aptos-move/aptos-native-interface",
-    "aptos-move/aptos-release-builder",
+    # "aptos-move/aptos-release-builder",
     "aptos-move/aptos-resource-viewer",
     "aptos-move/aptos-sdk-builder",
-    "aptos-move/aptos-transaction-benchmarks",
-    "aptos-move/aptos-transactional-test-harness",
-    "aptos-move/aptos-validator-interface",
+    # "aptos-move/aptos-transaction-benchmarks",
+    # "aptos-move/aptos-transactional-test-harness",
+    # "aptos-move/aptos-validator-interface",
     "aptos-move/aptos-vm",
-    "aptos-move/aptos-vm-benchmarks",
+    # "aptos-move/aptos-vm-benchmarks",
     "aptos-move/aptos-vm-logging",
-    "aptos-move/aptos-vm-profiling",
+    # "aptos-move/aptos-vm-profiling",
     "aptos-move/aptos-vm-types",
-    "aptos-move/block-executor",
-    "aptos-move/e2e-benchmark",
-    "aptos-move/e2e-move-tests",
-    "aptos-move/e2e-tests",
-    "aptos-move/e2e-testsuite",
-    "aptos-move/framework",
-    "aptos-move/framework/cached-packages",
-    "aptos-move/framework/table-natives",
-    "aptos-move/move-examples",
-    "aptos-move/mvhashmap",
-    "aptos-move/package-builder",
-    "aptos-move/vm-genesis",
-    "aptos-node",
+    # "aptos-move/block-executor",
+    # "aptos-move/e2e-benchmark",
+    # "aptos-move/e2e-move-tests",
+    # "aptos-move/e2e-tests",
+    # "aptos-move/e2e-testsuite",
+    # "aptos-move/framework",
+    # "aptos-move/framework/cached-packages",
+    # "aptos-move/framework/table-natives",
+    # "aptos-move/move-examples",
+    # "aptos-move/mvhashmap",
+    # "aptos-move/package-builder",
+    # "aptos-move/vm-genesis",
+    # "aptos-node",
     "aptos-utils",
     "config",
     "config/global-constants",
-    "consensus",
-    "consensus/consensus-types",
-    "consensus/safety-rules",
-    "crates/aptos",
-    "crates/aptos-admin-service",
-    "crates/aptos-api-tester",
+    # "consensus",
+    # "consensus/consensus-types",
+    # "consensus/safety-rules",
+    # "crates/aptos",
+    # "crates/aptos-admin-service",
+    # "crates/aptos-api-tester",
     "crates/aptos-bcs-utils",
     "crates/aptos-bitvec",
     "crates/aptos-build-info",
-    "crates/aptos-collections",
+    # "crates/aptos-collections",
     "crates/aptos-compression",
     "crates/aptos-crypto",
     "crates/aptos-crypto-derive",
-    "crates/aptos-debugger",
+    # "crates/aptos-debugger",
     "crates/aptos-dkg",
     "crates/aptos-drop-helper",
-    "crates/aptos-enum-conversion-derive",
-    "crates/aptos-faucet/cli",
-    "crates/aptos-faucet/core",
-    "crates/aptos-faucet/metrics-server",
-    "crates/aptos-faucet/service",
+    # "crates/aptos-enum-conversion-derive",
+    # "crates/aptos-faucet/cli",
+    # "crates/aptos-faucet/core",
+    # "crates/aptos-faucet/metrics-server",
+    # "crates/aptos-faucet/service",
     "crates/aptos-genesis",
-    "crates/aptos-github-client",
+    # "crates/aptos-github-client",
     "crates/aptos-id-generator",
     "crates/aptos-infallible",
-    "crates/aptos-inspection-service",
-    "crates/aptos-jwk-consensus",
+    # "crates/aptos-inspection-service",
+    # "crates/aptos-jwk-consensus",
     "crates/aptos-keygen",
     "crates/aptos-ledger",
     "crates/aptos-log-derive",
     "crates/aptos-logger",
     "crates/aptos-metrics-core",
-    "crates/aptos-network-checker",
+    # "crates/aptos-network-checker",
     "crates/aptos-node-identity",
     "crates/aptos-openapi",
-    "crates/aptos-profiler",
+    # "crates/aptos-profiler",
     "crates/aptos-proptest-helpers",
     "crates/aptos-push-metrics",
-    "crates/aptos-rate-limiter",
+    # "crates/aptos-rate-limiter",
     "crates/aptos-rest-client",
-    "crates/aptos-retrier",
-    "crates/aptos-rosetta",
-    "crates/aptos-rosetta-cli",
+    # "crates/aptos-retrier",
+    # "crates/aptos-rosetta",
+    # "crates/aptos-rosetta-cli",
     "crates/aptos-runtimes",
-    "crates/aptos-speculative-state-helper",
-    "crates/aptos-system-utils",
-    "crates/aptos-telemetry",
-    "crates/aptos-telemetry-service",
-    "crates/aptos-temppath",
-    "crates/aptos-time-service",
-    "crates/aptos-warp-webserver",
-    "crates/bounded-executor",
-    "crates/channel",
-    "crates/crash-handler",
-    "crates/fallible",
-    "crates/indexer",
-    "crates/jwk-utils",
-    "crates/node-resource-metrics",
-    "crates/num-variants",
-    "crates/proxy",
-    "crates/reliable-broadcast",
-    "crates/short-hex-str",
-    "crates/transaction-emitter",
-    "crates/transaction-emitter-lib",
-    "crates/transaction-generator-lib",
-    "crates/validator-transaction-pool",
-    "devtools/aptos-cargo-cli",
-    "dkg",
-    "ecosystem/indexer-grpc/indexer-grpc-cache-worker",
-    "ecosystem/indexer-grpc/indexer-grpc-data-service",
-    "ecosystem/indexer-grpc/indexer-grpc-file-store",
-    "ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller",
-    "ecosystem/indexer-grpc/indexer-grpc-fullnode",
-    "ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark",
-    "ecosystem/indexer-grpc/indexer-grpc-server-framework",
-    "ecosystem/indexer-grpc/indexer-grpc-table-info",
-    "ecosystem/indexer-grpc/indexer-grpc-utils",
-    "ecosystem/indexer-grpc/indexer-test-transactions",
-    "ecosystem/indexer-grpc/indexer-transaction-generator",
-    "ecosystem/indexer-grpc/transaction-filter",
-    "ecosystem/nft-metadata-crawler-parser",
-    "ecosystem/node-checker",
-    "ecosystem/node-checker/fn-check-client",
+    # "crates/aptos-speculative-state-helper",
+    # "crates/aptos-system-utils",
+    # "crates/aptos-telemetry",
+    # "crates/aptos-telemetry-service",
+    # "crates/aptos-temppath",
+    # "crates/aptos-time-service",
+    # "crates/aptos-warp-webserver",
+    # "crates/bounded-executor",
+    # "crates/channel",
+    # "crates/crash-handler",
+    # "crates/fallible",
+    # "crates/indexer",
+    # "crates/jwk-utils",
+    # "crates/node-resource-metrics",
+    # "crates/num-variants",
+    # "crates/proxy",
+    # "crates/reliable-broadcast",
+    # "crates/short-hex-str",
+    # "crates/transaction-emitter",
+    # "crates/transaction-emitter-lib",
+    # "crates/transaction-generator-lib",
+    # "crates/validator-transaction-pool",
+    # "devtools/aptos-cargo-cli",
+    # "dkg",
+    # "ecosystem/indexer-grpc/indexer-grpc-cache-worker",
+    # "ecosystem/indexer-grpc/indexer-grpc-data-service",
+    # "ecosystem/indexer-grpc/indexer-grpc-file-store",
+    # "ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller",
+    # "ecosystem/indexer-grpc/indexer-grpc-fullnode",
+    # "ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark",
+    # "ecosystem/indexer-grpc/indexer-grpc-server-framework",
+    # "ecosystem/indexer-grpc/indexer-grpc-table-info",
+    # "ecosystem/indexer-grpc/indexer-grpc-utils",
+    # "ecosystem/indexer-grpc/indexer-test-transactions",
+    # "ecosystem/indexer-grpc/indexer-transaction-generator",
+    # "ecosystem/indexer-grpc/transaction-filter",
+    # "ecosystem/nft-metadata-crawler-parser",
+    # "ecosystem/node-checker",
+    # "ecosystem/node-checker/fn-check-client",
     "execution/block-partitioner",
-    "execution/executor",
-    "execution/executor-benchmark",
-    "execution/executor-service",
+    # "execution/executor",
+    # "execution/executor-benchmark",
+    # "execution/executor-service",
     "execution/executor-test-helpers",
-    "execution/executor-types",
-    "experimental/execution/ptx-executor",
-    "experimental/runtimes",
-    "experimental/storage/hexy",
-    "experimental/storage/layered-map",
-    "keyless/circuit",
-    "keyless/common",
-    "keyless/pepper/common",
-    "keyless/pepper/example-client-rust",
-    "keyless/pepper/service",
+    # "execution/executor-types",
+    # "experimental/execution/ptx-executor",
+    # "experimental/runtimes",
+    # "experimental/storage/hexy",
+    # "experimental/storage/layered-map",
+    # "keyless/circuit",
+    # "keyless/common",
+    # "keyless/pepper/common",
+    # "keyless/pepper/example-client-rust",
+    # "keyless/pepper/service",
     "mempool",
-    "network/benchmark",
-    "network/builder",
-    "network/discovery",
-    "network/framework",
+    # "network/benchmark",
+    # "network/builder",
+    # "network/discovery",
+    # "network/framework",
     "network/memsocket",
     "network/netcore",
-    "peer-monitoring-service/client",
-    "peer-monitoring-service/server",
-    "peer-monitoring-service/types",
-    "protos/rust",
-    "sdk",
-    "secure/net",
-    "secure/storage",
-    "secure/storage/vault",
-    "state-sync/aptos-data-client",
-    "state-sync/data-streaming-service",
-    "state-sync/inter-component/consensus-notifications",
-    "state-sync/inter-component/event-notifications",
-    "state-sync/inter-component/mempool-notifications",
-    "state-sync/inter-component/storage-service-notifications",
-    "state-sync/state-sync-driver",
-    "state-sync/storage-service/client",
-    "state-sync/storage-service/server",
-    "state-sync/storage-service/types",
+    # "peer-monitoring-service/client",
+    # "peer-monitoring-service/server",
+    # "peer-monitoring-service/types",
+    # "protos/rust",
+    # "sdk",
+    # "secure/net",
+    # "secure/storage",
+    # "secure/storage/vault",
+    # "state-sync/aptos-data-client",
+    # "state-sync/data-streaming-service",
+    # "state-sync/inter-component/consensus-notifications",
+    # "state-sync/inter-component/event-notifications",
+    # "state-sync/inter-component/mempool-notifications",
+    # "state-sync/inter-component/storage-service-notifications",
+    # "state-sync/state-sync-driver",
+    # "state-sync/storage-service/client",
+    # "state-sync/storage-service/server",
+    # "state-sync/storage-service/types",
     "storage/accumulator",
-    "storage/aptosdb",
-    "storage/backup/backup-cli",
-    "storage/backup/backup-service",
-    "storage/db-tool",
-    "storage/executable-store",
+    # "storage/aptosdb",
+    # "storage/backup/backup-cli",
+    # "storage/backup/backup-service",
+    # "storage/db-tool",
+    # "storage/executable-store",
     "storage/indexer",
     "storage/indexer_schemas",
     "storage/jellyfish-merkle",
-    "storage/rocksdb-options",
-    "storage/schemadb",
+    # "storage/rocksdb-options",
+    # "storage/schemadb",
     "storage/scratchpad",
-    "storage/storage-interface",
-    "testsuite/forge",
-    "testsuite/forge-cli",
-    "testsuite/fuzzer",
-    "testsuite/fuzzer/fuzz",
-    "testsuite/generate-format",
-    "testsuite/module-publish",
-    "testsuite/smoke-test",
-    "testsuite/testcases",
+    # "storage/storage-interface",
+    # "testsuite/forge",
+    # "testsuite/forge-cli",
+    # "testsuite/fuzzer",
+    # "testsuite/fuzzer/fuzz",
+    # "testsuite/generate-format",
+    # "testsuite/module-publish",
+    # "testsuite/smoke-test",
+    # "testsuite/testcases",
     "third_party/move/evm/exec-utils",
     "third_party/move/evm/extract-ethereum-abi",
-    # third_party/move
+    # # third_party/move
     "third_party/move/extensions/async/move-async-vm",
     "third_party/move/extensions/move-table-extension",
     "third_party/move/move-binary-format",
@@ -209,8 +209,8 @@ members = [
     "third_party/move/move-compiler-v2/tools/testdiff",
     "third_party/move/move-compiler-v2/transactional-tests",
     "third_party/move/move-compiler/transactional-tests",
-    "third_party/move/move-core/types",
-    "third_party/move/move-examples",
+    # "third_party/move/move-core/types",
+    # "third_party/move/move-examples",
     "third_party/move/move-ir-compiler",
     "third_party/move/move-ir-compiler/move-bytecode-source-map",
     "third_party/move/move-ir-compiler/move-ir-to-bytecode",
@@ -238,19 +238,19 @@ members = [
     "third_party/move/testing-infra/module-generation",
     "third_party/move/testing-infra/test-generation",
     "third_party/move/testing-infra/transactional-test-runner",
-    "third_party/move/tools/move-bytecode-utils",
-    "third_party/move/tools/move-bytecode-viewer",
-    "third_party/move/tools/move-cli",
-    "third_party/move/tools/move-coverage",
-    "third_party/move/tools/move-disassembler",
-    "third_party/move/tools/move-explain",
-    "third_party/move/tools/move-package",
-    "third_party/move/tools/move-resource-viewer",
-    "third_party/move/tools/move-unit-test",
-    "tools/calc-dep-sizes",
-    "tools/compute-module-expansion-size",
-    "types",
-    "vm-validator",
+    # "third_party/move/tools/move-bytecode-utils",
+    # "third_party/move/tools/move-bytecode-viewer",
+    # "third_party/move/tools/move-cli",
+    # "third_party/move/tools/move-coverage",
+    # "third_party/move/tools/move-disassembler",
+    # "third_party/move/tools/move-explain",
+    # "third_party/move/tools/move-package",
+    # "third_party/move/tools/move-resource-viewer",
+    # "third_party/move/tools/move-unit-test",
+    # "tools/calc-dep-sizes",
+    # "tools/compute-module-expansion-size",
+    # "types",
+    # "vm-validator",
 ]
 
 # NOTE: default-members is the complete list of binaries that form the "production Aptos codebase". These members should
@@ -259,18 +259,18 @@ members = [
 #
 # For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
 default-members = [
-    "aptos-node",
-    "consensus/safety-rules",
-    "crates/aptos",
-    "crates/aptos-debugger",
-    "crates/aptos-faucet/service",
+    # "aptos-node",
+    # "consensus/safety-rules",
+    # "crates/aptos",
+    # "crates/aptos-debugger",
+    # "crates/aptos-faucet/service",
     "crates/aptos-keygen",
-    "crates/aptos-rate-limiter",
-    "crates/aptos-rosetta",
-    "crates/transaction-emitter",
-    "aptos-move/framework",
-    "storage/backup/backup-cli",
-    "ecosystem/node-checker",
+    # "crates/aptos-rate-limiter",
+    # "crates/aptos-rosetta",
+    # "crates/transaction-emitter",
+    # "aptos-move/framework",
+    # "storage/backup/backup-cli",
+    # "ecosystem/node-checker",
 ]
 
 # All workspace members should inherit these keys
@@ -287,15 +287,15 @@ rust-version = "1.78.0"
 [workspace.dependencies]
 # Internal crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
-aptos = { path = "crates/aptos" }
+# aptos = { path = "crates/aptos" }
 aptos-accumulator = { path = "storage/accumulator" }
-aptos-admin-service = { path = "crates/aptos-admin-service" }
+# aptos-admin-service = { path = "crates/aptos-admin-service" }
 aptos-aggregator = { path = "aptos-move/aptos-aggregator" }
 aptos-api = { path = "api" }
 aptos-api-test-context = { path = "api/test-context" }
 aptos-api-types = { path = "api/types" }
-aptos-backup-cli = { path = "storage/backup/backup-cli" }
-aptos-backup-service = { path = "storage/backup/backup-service" }
+# aptos-backup-cli = { path = "storage/backup/backup-cli" }
+# aptos-backup-service = { path = "storage/backup/backup-service" }
 aptos-bcs-utils = { path = "crates/aptos-bcs-utils" }
 aptos-bounded-executor = { path = "crates/bounded-executor" }
 aptos-block-executor = { path = "aptos-move/block-executor" }
@@ -303,46 +303,46 @@ aptos-bitvec = { path = "crates/aptos-bitvec" }
 aptos-build-info = { path = "crates/aptos-build-info" }
 aptos-cached-packages = { path = "aptos-move/framework/cached-packages" }
 aptos-channels = { path = "crates/channel" }
-aptos-cli-common = { path = "crates/aptos-cli-common" }
-aptos-collections = { path = "crates/aptos-collections" }
+# aptos-cli-common = { path = "crates/aptos-cli-common" }
+# aptos-collections = { path = "crates/aptos-collections" }
 aptos-compression = { path = "crates/aptos-compression" }
-aptos-consensus = { path = "consensus" }
-aptos-consensus-notifications = { path = "state-sync/inter-component/consensus-notifications" }
+# aptos-consensus = { path = "consensus" }
+# aptos-consensus-notifications = { path = "state-sync/inter-component/consensus-notifications" }
 aptos-consensus-types = { path = "consensus/consensus-types" }
 aptos-config = { path = "config" }
-aptos-crash-handler = { path = "crates/crash-handler" }
+# aptos-crash-handler = { path = "crates/crash-handler" }
 aptos-crypto = { path = "crates/aptos-crypto" }
 aptos-crypto-derive = { path = "crates/aptos-crypto-derive" }
-aptos-data-client = { path = "state-sync/aptos-data-client" }
-aptos-data-streaming-service = { path = "state-sync/data-streaming-service" }
+# aptos-data-client = { path = "state-sync/aptos-data-client" }
+# aptos-data-streaming-service = { path = "state-sync/data-streaming-service" }
 aptos-db = { path = "storage/aptosdb" }
 aptos-db-indexer = { path = "storage/indexer" }
 aptos-db-indexer-schemas = { path = "storage/indexer_schemas" }
-aptos-db-tool = { path = "storage/db-tool" }
-aptos-debugger = { path = "crates/aptos-debugger" }
+# aptos-db-tool = { path = "storage/db-tool" }
+# aptos-debugger = { path = "crates/aptos-debugger" }
 aptos-dkg = { path = "crates/aptos-dkg" }
-aptos-dkg-runtime = { path = "dkg" }
+# aptos-dkg-runtime = { path = "dkg" }
 aptos-drop-helper = { path = "crates/aptos-drop-helper" }
 aptos-event-notifications = { path = "state-sync/inter-component/event-notifications" }
-aptos-executable-store = { path = "storage/executable-store" }
+# aptos-executable-store = { path = "storage/executable-store" }
 aptos-executor = { path = "execution/executor" }
 aptos-block-partitioner = { path = "execution/block-partitioner" }
-aptos-enum-conversion-derive = { path = "crates/aptos-enum-conversion-derive" }
+# aptos-enum-conversion-derive = { path = "crates/aptos-enum-conversion-derive" }
 aptos-executor-service = { path = "execution/executor-service" }
 aptos-executor-test-helpers = { path = "execution/executor-test-helpers" }
 aptos-executor-types = { path = "execution/executor-types" }
-aptos-experimental-hexy = { path = "experimental/storage/hexy" }
-aptos-experimental-layered-map = { path = "experimental/storage/layered-map" }
-aptos-experimental-ptx-executor = { path = "experimental/execution/ptx-executor" }
+# aptos-experimental-hexy = { path = "experimental/storage/hexy" }
+# aptos-experimental-layered-map = { path = "experimental/storage/layered-map" }
+# aptos-experimental-ptx-executor = { path = "experimental/execution/ptx-executor" }
 aptos-experimental-runtimes = { path = "experimental/runtimes" }
-aptos-faucet-cli = { path = "crates/aptos-faucet/cli" }
-aptos-faucet-core = { path = "crates/aptos-faucet/core" }
-aptos-faucet-service = { path = "crates/aptos-faucet/service" }
-aptos-faucet-metrics-server = { path = "crates/aptos-faucet/metrics-server" }
-aptos-fallible = { path = "crates/fallible" }
-aptos-forge = { path = "testsuite/forge" }
+# aptos-faucet-cli = { path = "crates/aptos-faucet/cli" }
+# aptos-faucet-core = { path = "crates/aptos-faucet/core" }
+# aptos-faucet-service = { path = "crates/aptos-faucet/service" }
+# aptos-faucet-metrics-server = { path = "crates/aptos-faucet/metrics-server" }
+# aptos-fallible = { path = "crates/fallible" }
+# aptos-forge = { path = "testsuite/forge" }
 aptos-framework = { path = "aptos-move/framework" }
-fuzzer = { path = "testsuite/fuzzer" }
+# fuzzer = { path = "testsuite/fuzzer" }
 aptos-abstract-gas-usage = { path = "aptos-move/aptos-abstract-gas-usage" }
 aptos-gas-meter = { path = "aptos-move/aptos-gas-meter" }
 aptos-gas-algebra = { path = "aptos-move/aptos-gas-algebra" }
@@ -351,26 +351,26 @@ aptos-gas-profiling = { path = "aptos-move/aptos-gas-profiling" }
 aptos-gas-schedule = { path = "aptos-move/aptos-gas-schedule" }
 aptos-gas-schedule-updator = { path = "aptos-move/aptos-gas-schedule-updator" }
 aptos-genesis = { path = "crates/aptos-genesis" }
-aptos-github-client = { path = "crates/aptos-github-client" }
+# aptos-github-client = { path = "crates/aptos-github-client" }
 aptos-global-constants = { path = "config/global-constants" }
 aptos-id-generator = { path = "crates/aptos-id-generator" }
-aptos-indexer = { path = "crates/indexer" }
-aptos-indexer-grpc-cache-worker = { path = "ecosystem/indexer-grpc/indexer-grpc-cache-worker" }
-aptos-indexer-grpc-data-service = { path = "ecosystem/indexer-grpc/indexer-grpc-data-service" }
-aptos-indexer-grpc-file-store = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store" }
-aptos-indexer-grpc-file-store-backfiller = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller" }
+# aptos-indexer = { path = "crates/indexer" }
+# aptos-indexer-grpc-cache-worker = { path = "ecosystem/indexer-grpc/indexer-grpc-cache-worker" }
+# aptos-indexer-grpc-data-service = { path = "ecosystem/indexer-grpc/indexer-grpc-data-service" }
+# aptos-indexer-grpc-file-store = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store" }
+# aptos-indexer-grpc-file-store-backfiller = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller" }
 aptos-indexer-grpc-fullnode = { path = "ecosystem/indexer-grpc/indexer-grpc-fullnode" }
-aptos-indexer-grpc-in-memory-cache-benchmark = { path = "ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark" }
+# aptos-indexer-grpc-in-memory-cache-benchmark = { path = "ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark" }
 aptos-indexer-grpc-table-info = { path = "ecosystem/indexer-grpc/indexer-grpc-table-info" }
-aptos-indexer-test-transactions = { path = "ecosystem/indexer-grpc/indexer-test-transactions" }
+# aptos-indexer-test-transactions = { path = "ecosystem/indexer-grpc/indexer-test-transactions" }
 aptos-indexer-grpc-utils = { path = "ecosystem/indexer-grpc/indexer-grpc-utils" }
-aptos-indexer-grpc-server-framework = { path = "ecosystem/indexer-grpc/indexer-grpc-server-framework" }
-aptos-indexer-transaction-generator = { path = "ecosystem/indexer-grpc/indexer-transaction-generator" }
+# aptos-indexer-grpc-server-framework = { path = "ecosystem/indexer-grpc/indexer-grpc-server-framework" }
+# aptos-indexer-transaction-generator = { path = "ecosystem/indexer-grpc/indexer-transaction-generator" }
 aptos-infallible = { path = "crates/aptos-infallible" }
-aptos-inspection-service = { path = "crates/aptos-inspection-service" }
+# aptos-inspection-service = { path = "crates/aptos-inspection-service" }
 aptos-jellyfish-merkle = { path = "storage/jellyfish-merkle" }
-aptos-jwk-consensus = { path = "crates/aptos-jwk-consensus" }
-aptos-jwk-utils = { path = "crates/jwk-utils" }
+# aptos-jwk-consensus = { path = "crates/aptos-jwk-consensus" }
+# aptos-jwk-utils = { path = "crates/jwk-utils" }
 aptos-keygen = { path = "crates/aptos-keygen" }
 aptos-language-e2e-tests = { path = "aptos-move/e2e-tests" }
 aptos-ledger = { path = "crates/aptos-ledger" }
@@ -381,46 +381,46 @@ aptos-mempool = { path = "mempool" }
 aptos-mempool-notifications = { path = "state-sync/inter-component/mempool-notifications" }
 aptos-memsocket = { path = "network/memsocket" }
 aptos-metrics-core = { path = "crates/aptos-metrics-core" }
-aptos-move-debugger = { path = "aptos-move/aptos-debugger" }
-aptos-move-examples = { path = "aptos-move/move-examples" }
-aptos-move-e2e-benchmark = { path = "aptos-move/e2e-benchmark" }
+# aptos-move-debugger = { path = "aptos-move/aptos-debugger" }
+# aptos-move-examples = { path = "aptos-move/move-examples" }
+# aptos-move-e2e-benchmark = { path = "aptos-move/e2e-benchmark" }
 aptos-mvhashmap = { path = "aptos-move/mvhashmap" }
 aptos-native-interface = { path = "aptos-move/aptos-native-interface" }
 aptos-netcore = { path = "network/netcore" }
 aptos-network = { path = "network/framework" }
-aptos-network-benchmark = { path = "network/benchmark" }
-aptos-network-builder = { path = "network/builder" }
-aptos-network-checker = { path = "crates/aptos-network-checker" }
-aptos-network-discovery = { path = "network/discovery" }
-aptos-nft-metadata-crawler-parser = { path = "ecosystem/nft-metadata-crawler-parser" }
-aptos-node = { path = "aptos-node" }
-aptos-node-checker = { path = "ecosystem/node-checker" }
+# aptos-network-benchmark = { path = "network/benchmark" }
+# aptos-network-builder = { path = "network/builder" }
+# aptos-network-checker = { path = "crates/aptos-network-checker" }
+# aptos-network-discovery = { path = "network/discovery" }
+# aptos-nft-metadata-crawler-parser = { path = "ecosystem/nft-metadata-crawler-parser" }
+# aptos-node = { path = "aptos-node" }
+# aptos-node-checker = { path = "ecosystem/node-checker" }
 aptos-node-identity = { path = "crates/aptos-node-identity" }
 aptos-node-resource-metrics = { path = "crates/node-resource-metrics" }
 aptos-num-variants = { path = "crates/num-variants" }
 aptos-openapi = { path = "crates/aptos-openapi" }
 aptos-package-builder = { path = "aptos-move/package-builder" }
-aptos-peer-monitoring-service-client = { path = "peer-monitoring-service/client" }
-aptos-peer-monitoring-service-server = { path = "peer-monitoring-service/server" }
+# aptos-peer-monitoring-service-client = { path = "peer-monitoring-service/client" }
+# aptos-peer-monitoring-service-server = { path = "peer-monitoring-service/server" }
 aptos-peer-monitoring-service-types = { path = "peer-monitoring-service/types" }
-aptos-keyless-common = { path = "keyless/common" }
-aptos-keyless-pepper-common = { path = "keyless/pepper/common" }
-aptos-keyless-pepper-service = { path = "keyless/pepper/service" }
-aptos-profiler = { path = "crates/aptos-profiler" }
+# aptos-keyless-common = { path = "keyless/common" }
+# aptos-keyless-pepper-common = { path = "keyless/pepper/common" }
+# aptos-keyless-pepper-service = { path = "keyless/pepper/service" }
+# aptos-profiler = { path = "crates/aptos-profiler" }
 aptos-proptest-helpers = { path = "crates/aptos-proptest-helpers" }
 aptos-protos = { path = "protos/rust" }
 aptos-proxy = { path = "crates/proxy" }
 aptos-push-metrics = { path = "crates/aptos-push-metrics" }
-aptos-rate-limiter = { path = "crates/aptos-rate-limiter" }
-aptos-release-builder = { path = "aptos-move/aptos-release-builder" }
-aptos-reliable-broadcast = { path = "crates/reliable-broadcast" }
+# aptos-rate-limiter = { path = "crates/aptos-rate-limiter" }
+# aptos-release-builder = { path = "aptos-move/aptos-release-builder" }
+# aptos-reliable-broadcast = { path = "crates/reliable-broadcast" }
 aptos-resource-viewer = { path = "aptos-move/aptos-resource-viewer" }
 aptos-rest-client = { path = "crates/aptos-rest-client" }
-aptos-retrier = { path = "crates/aptos-retrier" }
+# aptos-retrier = { path = "crates/aptos-retrier" }
 aptos-rocksdb-options = { path = "storage/rocksdb-options" }
-aptos-rosetta = { path = "crates/aptos-rosetta" }
+# aptos-rosetta = { path = "crates/aptos-rosetta" }
 aptos-runtimes = { path = "crates/aptos-runtimes" }
-aptos-safety-rules = { path = "consensus/safety-rules" }
+# aptos-safety-rules = { path = "consensus/safety-rules" }
 aptos-schemadb = { path = "storage/schemadb" }
 aptos-scratchpad = { path = "storage/scratchpad" }
 aptos-sdk = { path = "sdk" }
@@ -429,36 +429,34 @@ aptos-secure-net = { path = "secure/net" }
 aptos-secure-storage = { path = "secure/storage" }
 aptos-short-hex-str = { path = "crates/short-hex-str" }
 aptos-speculative-state-helper = { path = "crates/aptos-speculative-state-helper" }
-aptos-state-sync-driver = { path = "state-sync/state-sync-driver" }
+# aptos-state-sync-driver = { path = "state-sync/state-sync-driver" }
 aptos-storage-interface = { path = "storage/storage-interface" }
-aptos-storage-service-client = { path = "state-sync/storage-service/client" }
-aptos-storage-service-notifications = { path = "state-sync/inter-component/storage-service-notifications" }
-aptos-storage-service-types = { path = "state-sync/storage-service/types" }
-aptos-storage-service-server = { path = "state-sync/storage-service/server" }
-aptos-system-utils = { path = "crates/aptos-system-utils" }
-aptos-transaction-filter = { path = "ecosystem/indexer-grpc/transaction-filter" }
-aptos-telemetry = { path = "crates/aptos-telemetry" }
-aptos-telemetry-service = { path = "crates/aptos-telemetry-service" }
+# aptos-storage-service-client = { path = "state-sync/storage-service/client" }
+# aptos-storage-service-notifications = { path = "state-sync/inter-component/storage-service-notifications" }
+# aptos-storage-service-types = { path = "state-sync/storage-service/types" }
+# aptos-storage-service-server = { path = "state-sync/storage-service/server" }
+# aptos-system-utils = { path = "crates/aptos-system-utils" }
+# aptos-transaction-filter = { path = "ecosystem/indexer-grpc/transaction-filter" }
+# aptos-telemetry = { path = "crates/aptos-telemetry" }
+# aptos-telemetry-service = { path = "crates/aptos-telemetry-service" }
 aptos-temppath = { path = "crates/aptos-temppath" }
-aptos-testcases = { path = "testsuite/testcases" }
-aptos-time-service = { path = "crates/aptos-time-service", features = [
-    "async",
-] }
-aptos-transaction-emitter-lib = { path = "crates/transaction-emitter-lib" }
-aptos-transaction-generator-lib = { path = "crates/transaction-generator-lib" }
-aptos-transactional-test-harness = { path = "aptos-move/aptos-transactional-test-harness" }
+# aptos-testcases = { path = "testsuite/testcases" }
+aptos-time-service = { path = "crates/aptos-time-service", features = [    "async",] }
+# aptos-transaction-emitter-lib = { path = "crates/transaction-emitter-lib" }
+# aptos-transaction-generator-lib = { path = "crates/transaction-generator-lib" }
+# aptos-transactional-test-harness = { path = "aptos-move/aptos-transactional-test-harness" }
 aptos-types = { path = "types" }
 aptos-utils = { path = "aptos-utils" }
-aptos-validator-interface = { path = "aptos-move/aptos-validator-interface" }
-aptos-validator-transaction-pool = { path = "crates/validator-transaction-pool" }
+# aptos-validator-interface = { path = "aptos-move/aptos-validator-interface" }
+# aptos-validator-transaction-pool = { path = "crates/validator-transaction-pool" }
 aptos-vault-client = { path = "secure/storage/vault" }
 aptos-vm = { path = "aptos-move/aptos-vm" }
 aptos-vm-logging = { path = "aptos-move/aptos-vm-logging" }
 aptos-vm-genesis = { path = "aptos-move/vm-genesis" }
 aptos-vm-types = { path = "aptos-move/aptos-vm-types" }
 aptos-vm-validator = { path = "vm-validator" }
-aptos-warp-webserver = { path = "crates/aptos-warp-webserver" }
-aptos-cargo-cli = { path = "devtools/aptos-cargo-cli" }
+# aptos-warp-webserver = { path = "crates/aptos-warp-webserver" }
+# aptos-cargo-cli = { path = "devtools/aptos-cargo-cli" }
 
 # External crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -544,8 +544,8 @@ derivative = "2.2.0"
 # determinator = "0.12.0"
 derive_more = "0.99.11"
 # diesel = "2.1"
-# # Use the crate version once this feature gets released on crates.io:
-# # https://github.com/weiznich/diesel_async/commit/e165e8c96a6c540ebde2d6d7c52df5c5620a4bf1
+# Use the crate version once this feature gets released on crates.io:
+# https://github.com/weiznich/diesel_async/commit/e165e8c96a6c540ebde2d6d7c52df5c5620a4bf1
 # diesel-async = { git = "https://github.com/weiznich/diesel_async.git", rev = "d02798c67065d763154d7272dd0c09b39757d0f2", features = [
 #     "async-connection-wrapper",
 #     "postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,23 +45,23 @@ members = [
     "aptos-utils",
     "config",
     "config/global-constants",
-    # "consensus",
-    # "consensus/consensus-types",
-    # "consensus/safety-rules",
+    "consensus",
+    "consensus/consensus-types",
+    "consensus/safety-rules",
     # "crates/aptos",
     # "crates/aptos-admin-service",
     # "crates/aptos-api-tester",
     "crates/aptos-bcs-utils",
     "crates/aptos-bitvec",
     "crates/aptos-build-info",
-    # "crates/aptos-collections",
+    "crates/aptos-collections",
     "crates/aptos-compression",
     "crates/aptos-crypto",
     "crates/aptos-crypto-derive",
     # "crates/aptos-debugger",
     "crates/aptos-dkg",
     "crates/aptos-drop-helper",
-    # "crates/aptos-enum-conversion-derive",
+    "crates/aptos-enum-conversion-derive",
     # "crates/aptos-faucet/cli",
     # "crates/aptos-faucet/core",
     # "crates/aptos-faucet/metrics-server",
@@ -304,10 +304,10 @@ aptos-build-info = { path = "crates/aptos-build-info" }
 aptos-cached-packages = { path = "aptos-move/framework/cached-packages" }
 aptos-channels = { path = "crates/channel" }
 # aptos-cli-common = { path = "crates/aptos-cli-common" }
-# aptos-collections = { path = "crates/aptos-collections" }
+aptos-collections = { path = "crates/aptos-collections" }
 aptos-compression = { path = "crates/aptos-compression" }
 # aptos-consensus = { path = "consensus" }
-# aptos-consensus-notifications = { path = "state-sync/inter-component/consensus-notifications" }
+aptos-consensus-notifications = { path = "state-sync/inter-component/consensus-notifications" }
 aptos-consensus-types = { path = "consensus/consensus-types" }
 aptos-config = { path = "config" }
 # aptos-crash-handler = { path = "crates/crash-handler" }
@@ -327,7 +327,7 @@ aptos-event-notifications = { path = "state-sync/inter-component/event-notificat
 # aptos-executable-store = { path = "storage/executable-store" }
 aptos-executor = { path = "execution/executor" }
 aptos-block-partitioner = { path = "execution/block-partitioner" }
-# aptos-enum-conversion-derive = { path = "crates/aptos-enum-conversion-derive" }
+aptos-enum-conversion-derive = { path = "crates/aptos-enum-conversion-derive" }
 aptos-executor-service = { path = "execution/executor-service" }
 aptos-executor-test-helpers = { path = "execution/executor-test-helpers" }
 aptos-executor-types = { path = "execution/executor-types" }
@@ -339,7 +339,7 @@ aptos-experimental-runtimes = { path = "experimental/runtimes" }
 # aptos-faucet-core = { path = "crates/aptos-faucet/core" }
 # aptos-faucet-service = { path = "crates/aptos-faucet/service" }
 # aptos-faucet-metrics-server = { path = "crates/aptos-faucet/metrics-server" }
-# aptos-fallible = { path = "crates/fallible" }
+aptos-fallible = { path = "crates/fallible" }
 # aptos-forge = { path = "testsuite/forge" }
 aptos-framework = { path = "aptos-move/framework" }
 # fuzzer = { path = "testsuite/fuzzer" }
@@ -413,14 +413,14 @@ aptos-proxy = { path = "crates/proxy" }
 aptos-push-metrics = { path = "crates/aptos-push-metrics" }
 # aptos-rate-limiter = { path = "crates/aptos-rate-limiter" }
 # aptos-release-builder = { path = "aptos-move/aptos-release-builder" }
-# aptos-reliable-broadcast = { path = "crates/reliable-broadcast" }
+aptos-reliable-broadcast = { path = "crates/reliable-broadcast" }
 aptos-resource-viewer = { path = "aptos-move/aptos-resource-viewer" }
 aptos-rest-client = { path = "crates/aptos-rest-client" }
 # aptos-retrier = { path = "crates/aptos-retrier" }
 aptos-rocksdb-options = { path = "storage/rocksdb-options" }
 # aptos-rosetta = { path = "crates/aptos-rosetta" }
 aptos-runtimes = { path = "crates/aptos-runtimes" }
-# aptos-safety-rules = { path = "consensus/safety-rules" }
+aptos-safety-rules = { path = "consensus/safety-rules" }
 aptos-schemadb = { path = "storage/schemadb" }
 aptos-scratchpad = { path = "storage/scratchpad" }
 aptos-sdk = { path = "sdk" }
@@ -448,7 +448,7 @@ aptos-time-service = { path = "crates/aptos-time-service", features = [    "asyn
 aptos-types = { path = "types" }
 aptos-utils = { path = "aptos-utils" }
 # aptos-validator-interface = { path = "aptos-move/aptos-validator-interface" }
-# aptos-validator-transaction-pool = { path = "crates/validator-transaction-pool" }
+aptos-validator-transaction-pool = { path = "crates/validator-transaction-pool" }
 aptos-vault-client = { path = "secure/storage/vault" }
 aptos-vm = { path = "aptos-move/aptos-vm" }
 aptos-vm-logging = { path = "aptos-move/aptos-vm-logging" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -577,7 +577,9 @@ ff = { version = "0.13", features = ["derive"] }
 field_count = "0.1.1"
 file_diff = "1.0.0"
 firestore = "0.43.0"
-fixed = "1.25.1"
+# TODO there may be a conflict of the `fixed` version introduced by a circular dependency. If so use
+# cargo update -p fixed --precise 1.25.1
+fixed = "1.25.1" # see comment above
 flate2 = "1.0.24"
 flexi_logger = "0.27.4"
 futures = "0.3.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -463,11 +463,11 @@ aptos-vm-validator = { path = "vm-validator" }
 aes-gcm = "0.10.3"
 ahash = "0.8.11"
 atty = "0.2.14"
-nalgebra = "0.32"
-float-cmp = "0.9.0"
-again = "0.1.2"
+# nalgebra = "0.32"
+# float-cmp = "0.9.0"
+# again = "0.1.2"
 anyhow = "1.0.71"
-anstyle = "1.0.1"
+# anstyle = "1.0.1"
 arbitrary = { version = "1.3.2", features = ["derive"] }
 arc-swap = "1.6.0"
 arr_macro = "0.2.1"
@@ -479,36 +479,36 @@ ark-groth16 = "0.4.0"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", features = ["getrandom"] }
 aptos-moving-average = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf" }
-assert_approx_eq = "1.1.0"
+# assert_approx_eq = "1.1.0"
 assert_unordered = "0.3.5"
-async-channel = "1.7.1"
-async-mutex = "1.4.0"
-async-recursion = "1.0.5"
-async-stream = "0.3"
+# async-channel = "1.7.1"
+# async-mutex = "1.4.0"
+# async-recursion = "1.0.5"
+# async-stream = "0.3"
 async-trait = "0.1.53"
-axum = "0.7.5"
+# axum = "0.7.5"
 base64 = "0.13.0"
-base64-url = "2.0.1"
+# base64-url = "2.0.1"
 backoff = { version = "0.4.0", features = ["tokio"] }
 backtrace = "0.3.58"
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 better_any = "0.1.1"
-bellman = { version = "0.13.1", default-features = false }
-bigdecimal = { version = "0.4.0", features = ["serde"] }
-version-compare = "0.1.1"
+# bellman = { version = "0.13.1", default-features = false }
+# bigdecimal = { version = "0.4.0", features = ["serde"] }
+# version-compare = "0.1.1"
 bitvec = "1.0.1"
 blake2 = "0.10.4"
 blake2-rfc = "0.2.18"
 blst = "0.3.11"
 # The __private_bench feature exposes the Fp12 type which we need to implement a multi-threaded multi-pairing.
 blstrs = { version = "0.7.1", features = ["serde", "__private_bench"] }
-bollard = "0.15"
+# bollard = "0.15"
 bulletproofs = { version = "4.0.0" }
 byteorder = "1.4.3"
 bytes = { version = "1.4.0", features = ["serde"] }
-camino = { version = "1.1.6" }
+# camino = { version = "1.1.6" }
 chrono = { version = "0.4.19", features = ["clock", "serde"] }
-cfg_block = "0.1.1"
+# cfg_block = "0.1.1"
 cfg-if = "1.0.0"
 ciborium = "0.2"
 claims = "0.7"
@@ -524,57 +524,57 @@ codespan-reporting = "0.11.1"
 colored = "2.0.0"
 concurrent-queue = "2.2.0"
 console-subscriber = "0.3.0"
-const_format = "0.2.26"
+# const_format = "0.2.26"
 core_affinity = "0.8.1"
 coset = "0.3"
 criterion = "0.3.5"
-criterion-cpu-time = "0.1.0"
+# criterion-cpu-time = "0.1.0"
 crossbeam = "0.8.1"
 crossbeam-channel = "0.5.4"
 crossterm = "0.26.1"
-csv = "1.2.1"
+# csv = "1.2.1"
 curve25519-dalek = "3"
 curve25519-dalek-ng = "4"
 dashmap = { version = "5.5.3", features = ["inline"] }
 datatest-stable = "0.1.1"
-debug-ignore = { version = "1.0.3", features = ["serde"] }
+# debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"
-derivation-path = "0.2.0"
-derive_builder = "0.20.0"
-determinator = "0.12.0"
+# derivation-path = "0.2.0"
+# derive_builder = "0.20.0"
+# determinator = "0.12.0"
 derive_more = "0.99.11"
-diesel = "2.1"
-# Use the crate version once this feature gets released on crates.io:
-# https://github.com/weiznich/diesel_async/commit/e165e8c96a6c540ebde2d6d7c52df5c5620a4bf1
-diesel-async = { git = "https://github.com/weiznich/diesel_async.git", rev = "d02798c67065d763154d7272dd0c09b39757d0f2", features = [
-    "async-connection-wrapper",
-    "postgres",
-    "bb8",
-    "tokio",
-] }
-diesel_migrations = { version = "2.1.0", features = ["postgres"] }
+# diesel = "2.1"
+# # Use the crate version once this feature gets released on crates.io:
+# # https://github.com/weiznich/diesel_async/commit/e165e8c96a6c540ebde2d6d7c52df5c5620a4bf1
+# diesel-async = { git = "https://github.com/weiznich/diesel_async.git", rev = "d02798c67065d763154d7272dd0c09b39757d0f2", features = [
+#     "async-connection-wrapper",
+#     "postgres",
+#     "bb8",
+#     "tokio",
+# ] }
+# diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 difference = "2.0.0"
 digest = "0.9.0"
 dir-diff = "0.3.2"
-dirs = "5.0.1"
+# dirs = "5.0.1"
 dirs-next = "2.0.0"
 dunce = "1.0.4"
 ed25519-dalek = { version = "1.0.1", features = ["std", "serde"] }
 ed25519-dalek-bip32 = "0.2.0"
 either = "1.6.1"
 enum_dispatch = "0.3.12"
-env_logger = "0.10.0"
+# env_logger = "0.10.0"
 erased-serde = "0.3.13"
 ethabi = "18.0.0"
 ethnum = "1.5.0"
-event-listener = "2.5.3"
+# event-listener = "2.5.3"
 evm = { version = "0.33.1", features = ["tracing"] }
 evm-runtime = { version = "0.33.0", features = ["tracing"] }
 fail = "0.5.0"
 ff = { version = "0.13", features = ["derive"] }
-field_count = "0.1.1"
+# field_count = "0.1.1"
 file_diff = "1.0.0"
-firestore = "0.43.0"
+# firestore = "0.43.0"
 fixed = "1.25.1"
 flate2 = "1.0.24"
 flexi_logger = "0.27.4"
@@ -584,29 +584,29 @@ futures-core = "0.3.29"
 futures-util = "0.3.29"
 fxhash = "0.2.1"
 getrandom = "0.2.2"
-gcp-bigquery-client = "0.16.8"
+# gcp-bigquery-client = "0.16.8"
 get_if_addrs = "0.5.3"
-git2 = "0.16.1"
-glob = "0.3.0"
+# git2 = "0.16.1"
+# glob = "0.3.0"
 goldenfile = "1.5.2"
 google-cloud-storage = "0.13.0"
 group = "0.13"
-guppy = "0.17.5"
+# guppy = "0.17.5"
 handlebars = "4.2.2"
 hashbrown = "0.14.3"
 heck = "0.4.1"
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.3.4"
 hkdf = "0.10.0"
-hmac = "0.12.0"
+# hmac = "0.12.0"
 hostname = "0.3.1"
-http = "0.2.9"
+# http = "0.2.9"
 httpmock = "0.6.8"
 hyper = { version = "0.14.18", features = ["full"] }
-hyper-tls = "0.5.0"
-image = "0.24.5"
+# hyper-tls = "0.5.0"
+# image = "0.24.5"
 indexmap = "1.9.3"
-include_dir = { version = "0.7.2", features = ["glob"] }
+# include_dir = { version = "0.7.2", features = ["glob"] }
 indicatif = "0.15.0"
 indoc = "1.0.6"
 inferno = "0.11.14"
@@ -617,10 +617,10 @@ jemallocator = { version = "0.5.0", features = [
     "profiling",
     "unprefixed_malloc_on_supported_platforms",
 ] }
-jemalloc-sys = "0.5.4"
-json-patch = "0.2.6"
+# jemalloc-sys = "0.5.4"
+# json-patch = "0.2.6"
 jsonwebtoken = "8.1"
-jwt = "0.16.0"
+# jwt = "0.16.0"
 lazy_static = "1.4.0"
 libc = "0.2.147"
 libfuzzer-sys = "0.4.6"
@@ -639,7 +639,7 @@ more-asserts = "0.3.0"
 named-lock = "0.2.0"
 native-tls = "0.2.10"
 neptune = { version = "13.0.0", default_features = false }
-ntest = "0.9.0"
+# ntest = "0.9.0"
 num = "0.4.0"
 num-bigint = { version = "0.3.2", features = ["rand"] }
 num_cpus = "1.13.1"
@@ -654,11 +654,11 @@ p256 = { version = "0.13.2" }
 prettydiff = "0.6.2"
 primitive-types = { version = "0.10" }
 signature = "2.1.0"
-sec1 = "0.7.0"
+# sec1 = "0.7.0"
 pairing = "0.23"
 parking_lot = "0.12.0"
 paste = "1.0.7"
-pathsearch = "0.2.0"
+# pathsearch = "0.2.0"
 passkey-authenticator = { version = "0.2.0", features = ["testable"] }
 passkey-client = { version = "0.2.0" }
 passkey-types = { version = "0.2.0" }
@@ -672,25 +672,25 @@ poem = { git = "https://github.com/poem-web/poem.git", rev = "809b2816d3504beeba
 poem-openapi = { git = "https://github.com/poem-web/poem.git", rev = "809b2816d3504beeba140fef3fdfe9432d654c5b", features = ["swagger-ui", "url"] }
 poem-openapi-derive = { git = "https://github.com/poem-web/poem.git", rev = "809b2816d3504beeba140fef3fdfe9432d654c5b" }
 poseidon-ark = { git = "https://github.com/arnaucube/poseidon-ark.git", rev = "6d2487aa1308d9d3860a2b724c485d73095c1c68" }
-pprof = { version = "0.11", features = ["flamegraph", "protobuf-codec"] }
+# pprof = { version = "0.11", features = ["flamegraph", "protobuf-codec"] }
 pretty = "0.10.0"
 pretty_assertions = "1.2.1"
 procfs = "0.14.1"
 proc-macro2 = "1.0.38"
-project-root = "0.2.2"
+# project-root = "0.2.2"
 prometheus = { version = "0.13.3", default-features = false }
-prometheus-http-query = "0.5.2"
-prometheus-parse = "0.2.4"
+# prometheus-http-query = "0.5.2"
+# prometheus-parse = "0.2.4"
 proptest = "1.4.0"
 proptest-derive = "0.4.0"
 prost = { version = "0.12.3", features = ["no-recursion-limit"] }
-prost-types = "0.12.3"
-quanta = "0.10.1"
+# prost-types = "0.12.3"
+# quanta = "0.10.1"
 quick_cache = "0.5.1"
 quote = "1.0.18"
 rand = "0.7.3"
 rand_core = "0.5.1"
-random_word = "0.3.0"
+# random_word = "0.3.0"
 rayon = "1.5.2"
 redis = { version = "0.22.3", features = [
     "tokio-comp",
@@ -707,20 +707,20 @@ reqwest = { version = "0.11.11", features = [
     "multipart",
     "stream",
 ] }
-reqwest-middleware = "0.2.0"
-reqwest-retry = "0.2.1"
+# reqwest-middleware = "0.2.0"
+# reqwest-retry = "0.2.1"
 ring = { version = "0.16.20", features = ["std"] }
 ripemd = "0.1.1"
 rocksdb = { version = "0.22.0", features = ["lz4"] }
 rsa = { version = "0.9.6" }
-rstack-self = { version = "0.3.0", features = ["dw"], default_features = false }
-rstest = "0.15.0"
+# rstack-self = { version = "0.3.0", features = ["dw"], default_features = false }
+# rstest = "0.15.0"
 rusty-fork = "0.3.0"
 rustversion = "1.0.14"
 scopeguard = "1.2.0"
-sha-1 = "0.10.0"
+# sha-1 = "0.10.0"
 sha2 = "0.9.3"
-sha256 = "1.4.0"
+# sha256 = "1.4.0"
 sha2_0_10_6 = { package = "sha2", version = "0.10.6" }
 sha3 = "0.9.1"
 shell-words = "1.0.0"
@@ -732,7 +732,7 @@ serde_json = { version = "1.0.81", features = [
     "preserve_order",
     "arbitrary_precision",
 ] } # Note: arbitrary_precision is required to parse u256 in JSON
-serde_repr = "0.1"
+# serde_repr = "0.1"
 serde_merge = "0.1.3"
 serde-name = "0.1.1"
 serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
@@ -744,7 +744,7 @@ simplelog = "0.9.0"
 smallbitvec = "2.5.1"
 smallvec = "1.8.0"
 static_assertions = "1.1.0"
-stats_alloc = "0.1.8"
+# stats_alloc = "0.1.8"
 status-line = "0.2.0"
 strum = "0.24.1"
 strum_macros = "0.24.2"
@@ -758,19 +758,19 @@ test-case = "3.1.0"
 textwrap = "0.15.0"
 thiserror = "1.0.37"
 threadpool = "1.8.1"
-thread_local = "1.1.7"
-time = { version = "0.3.24", features = ["serde"] }
+# thread_local = "1.1.7"
+# time = { version = "0.3.24", features = ["serde"] }
 tiny-bip39 = "0.8.2"
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
-toml_edit = "0.14.3"
+# toml_edit = "0.14.3"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 trybuild = "1.0.80"
 tokio = { version = "1.35.1", features = ["full"] }
-tokio-io-timeout = "1.2.0"
-tokio-metrics = "0.3.1"
+# tokio-io-timeout = "1.2.0"
+# tokio-metrics = "0.3.1"
 tokio-retry = "0.3.0"
-tokio-scoped = { version = "0.2.0" }
+# tokio-scoped = { version = "0.2.0" }
 tokio-stream = { version = "0.1.14", features = ["fs"] }
 tokio-test = "0.4.1"
 tokio-util = { version = "0.7.2", features = ["compat", "codec"] }
@@ -794,7 +794,7 @@ ureq = { version = "1.5.4", features = [
     "native-tls",
 ], default_features = false }
 url = { version = "2.4.0", features = ["serde"] }
-uuid = { version = "1.0.0", features = ["v4", "serde"] }
+# uuid = { version = "1.0.0", features = ["v4", "serde"] }
 variant_count = "1.1.0"
 walkdir = "2.3.3"
 warp = { version = "0.3.5", features = ["tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -577,9 +577,6 @@ ff = { version = "0.13", features = ["derive"] }
 field_count = "0.1.1"
 file_diff = "1.0.0"
 firestore = "0.43.0"
-# TODO there may be a conflict of the `fixed` version introduced by a circular dependency. If so use
-# cargo update -p fixed --precise 1.25.1
-fixed = "1.25.1" # see comment above
 flate2 = "1.0.24"
 flexi_logger = "0.27.4"
 futures = "0.3.29"
@@ -712,8 +709,11 @@ reqwest = { version = "0.11.11", features = [
     "stream",
 ] }
 async-std = "1.10.0"
-tide = "0.16"
 surf = "2.3"
+# TODO there may be a conflict of the `fixed` version introduced by a circular dependency. If so use
+# cargo update -p fixed --precise 1.25.1
+fixed = "1.25.1" # see comment above
+# tide = "0.16" # TODO this leads to circular dependency
 reqwest-middleware = "0.2.0"
 reqwest-retry = "0.2.1"
 ring = { version = "0.16.20", features = ["std"] }

--- a/Cargo_reduced_for_decseq.toml
+++ b/Cargo_reduced_for_decseq.toml
@@ -2,55 +2,55 @@
 resolver = "2"
 
 members = [
-    "api",
-    "api/openapi-spec-generator",
-    "api/test-context",
-    "api/types",
+    # "api",
+    # "api/openapi-spec-generator",
+    # "api/test-context",
+    # "api/types",
     "aptos-move/aptos-abstract-gas-usage",
     "aptos-move/aptos-aggregator",
-    "aptos-move/aptos-debugger",
-    "aptos-move/aptos-e2e-comparison-testing",
+    # "aptos-move/aptos-debugger",
+    # "aptos-move/aptos-e2e-comparison-testing",
     "aptos-move/aptos-gas-algebra",
-    "aptos-move/aptos-gas-calibration",
+    # "aptos-move/aptos-gas-calibration",
     "aptos-move/aptos-gas-meter",
     "aptos-move/aptos-gas-profiling",
     "aptos-move/aptos-gas-schedule",
     "aptos-move/aptos-gas-schedule-updator",
     "aptos-move/aptos-memory-usage-tracker",
     "aptos-move/aptos-native-interface",
-    "aptos-move/aptos-release-builder",
+    # "aptos-move/aptos-release-builder",
     "aptos-move/aptos-resource-viewer",
     "aptos-move/aptos-sdk-builder",
-    "aptos-move/aptos-transaction-benchmarks",
-    "aptos-move/aptos-transactional-test-harness",
-    "aptos-move/aptos-validator-interface",
+    # "aptos-move/aptos-transaction-benchmarks",
+    # "aptos-move/aptos-transactional-test-harness",
+    # "aptos-move/aptos-validator-interface",
     "aptos-move/aptos-vm",
-    "aptos-move/aptos-vm-benchmarks",
+    # "aptos-move/aptos-vm-benchmarks",
     "aptos-move/aptos-vm-logging",
-    "aptos-move/aptos-vm-profiling",
+    # "aptos-move/aptos-vm-profiling",
     "aptos-move/aptos-vm-types",
-    "aptos-move/block-executor",
-    "aptos-move/e2e-benchmark",
-    "aptos-move/e2e-move-tests",
-    "aptos-move/e2e-tests",
-    "aptos-move/e2e-testsuite",
-    "aptos-move/framework",
-    "aptos-move/framework/cached-packages",
-    "aptos-move/framework/table-natives",
-    "aptos-move/move-examples",
-    "aptos-move/mvhashmap",
-    "aptos-move/package-builder",
-    "aptos-move/vm-genesis",
-    "aptos-node",
+    # "aptos-move/block-executor",
+    # "aptos-move/e2e-benchmark",
+    # "aptos-move/e2e-move-tests",
+    # "aptos-move/e2e-tests",
+    # "aptos-move/e2e-testsuite",
+    # "aptos-move/framework",
+    # "aptos-move/framework/cached-packages",
+    # "aptos-move/framework/table-natives",
+    # "aptos-move/move-examples",
+    # "aptos-move/mvhashmap",
+    # "aptos-move/package-builder",
+    # "aptos-move/vm-genesis",
+    # "aptos-node",
     "aptos-utils",
     "config",
     "config/global-constants",
     "consensus",
     "consensus/consensus-types",
     "consensus/safety-rules",
-    "crates/aptos",
-    "crates/aptos-admin-service",
-    "crates/aptos-api-tester",
+    # "crates/aptos",
+    # "crates/aptos-admin-service",
+    # "crates/aptos-api-tester",
     "crates/aptos-bcs-utils",
     "crates/aptos-bitvec",
     "crates/aptos-build-info",
@@ -58,140 +58,140 @@ members = [
     "crates/aptos-compression",
     "crates/aptos-crypto",
     "crates/aptos-crypto-derive",
-    "crates/aptos-debugger",
+    # "crates/aptos-debugger",
     "crates/aptos-dkg",
     "crates/aptos-drop-helper",
     "crates/aptos-enum-conversion-derive",
-    "crates/aptos-faucet/cli",
-    "crates/aptos-faucet/core",
-    "crates/aptos-faucet/metrics-server",
-    "crates/aptos-faucet/service",
+    # "crates/aptos-faucet/cli",
+    # "crates/aptos-faucet/core",
+    # "crates/aptos-faucet/metrics-server",
+    # "crates/aptos-faucet/service",
     "crates/aptos-genesis",
-    "crates/aptos-github-client",
+    # "crates/aptos-github-client",
     "crates/aptos-id-generator",
     "crates/aptos-infallible",
-    "crates/aptos-inspection-service",
-    "crates/aptos-jwk-consensus",
+    # "crates/aptos-inspection-service",
+    # "crates/aptos-jwk-consensus",
     "crates/aptos-keygen",
     "crates/aptos-ledger",
     "crates/aptos-log-derive",
     "crates/aptos-logger",
     "crates/aptos-metrics-core",
-    "crates/aptos-network-checker",
+    # "crates/aptos-network-checker",
     "crates/aptos-node-identity",
     "crates/aptos-openapi",
-    "crates/aptos-profiler",
+    # "crates/aptos-profiler",
     "crates/aptos-proptest-helpers",
     "crates/aptos-push-metrics",
-    "crates/aptos-rate-limiter",
+    # "crates/aptos-rate-limiter",
     "crates/aptos-rest-client",
-    "crates/aptos-retrier",
-    "crates/aptos-rosetta",
-    "crates/aptos-rosetta-cli",
+    # "crates/aptos-retrier",
+    # "crates/aptos-rosetta",
+    # "crates/aptos-rosetta-cli",
     "crates/aptos-runtimes",
-    "crates/aptos-speculative-state-helper",
-    "crates/aptos-system-utils",
-    "crates/aptos-telemetry",
-    "crates/aptos-telemetry-service",
-    "crates/aptos-temppath",
-    "crates/aptos-time-service",
-    "crates/aptos-warp-webserver",
-    "crates/bounded-executor",
-    "crates/channel",
-    "crates/crash-handler",
-    "crates/fallible",
-    "crates/indexer",
-    "crates/jwk-utils",
-    "crates/node-resource-metrics",
-    "crates/num-variants",
-    "crates/proxy",
-    "crates/reliable-broadcast",
-    "crates/short-hex-str",
-    "crates/transaction-emitter",
-    "crates/transaction-emitter-lib",
-    "crates/transaction-generator-lib",
-    "crates/validator-transaction-pool",
-    "devtools/aptos-cargo-cli",
-    "dkg",
-    "ecosystem/indexer-grpc/indexer-grpc-cache-worker",
-    "ecosystem/indexer-grpc/indexer-grpc-data-service",
-    "ecosystem/indexer-grpc/indexer-grpc-file-store",
-    "ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller",
-    "ecosystem/indexer-grpc/indexer-grpc-fullnode",
-    "ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark",
-    "ecosystem/indexer-grpc/indexer-grpc-server-framework",
-    "ecosystem/indexer-grpc/indexer-grpc-table-info",
-    "ecosystem/indexer-grpc/indexer-grpc-utils",
-    "ecosystem/indexer-grpc/indexer-test-transactions",
-    "ecosystem/indexer-grpc/indexer-transaction-generator",
-    "ecosystem/indexer-grpc/transaction-filter",
-    "ecosystem/nft-metadata-crawler-parser",
-    "ecosystem/node-checker",
-    "ecosystem/node-checker/fn-check-client",
+    # "crates/aptos-speculative-state-helper",
+    # "crates/aptos-system-utils",
+    # "crates/aptos-telemetry",
+    # "crates/aptos-telemetry-service",
+    # "crates/aptos-temppath",
+    # "crates/aptos-time-service",
+    # "crates/aptos-warp-webserver",
+    # "crates/bounded-executor",
+    # "crates/channel",
+    # "crates/crash-handler",
+    # "crates/fallible",
+    # "crates/indexer",
+    # "crates/jwk-utils",
+    # "crates/node-resource-metrics",
+    # "crates/num-variants",
+    # "crates/proxy",
+    # "crates/reliable-broadcast",
+    # "crates/short-hex-str",
+    # "crates/transaction-emitter",
+    # "crates/transaction-emitter-lib",
+    # "crates/transaction-generator-lib",
+    # "crates/validator-transaction-pool",
+    # "devtools/aptos-cargo-cli",
+    # "dkg",
+    # "ecosystem/indexer-grpc/indexer-grpc-cache-worker",
+    # "ecosystem/indexer-grpc/indexer-grpc-data-service",
+    # "ecosystem/indexer-grpc/indexer-grpc-file-store",
+    # "ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller",
+    # "ecosystem/indexer-grpc/indexer-grpc-fullnode",
+    # "ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark",
+    # "ecosystem/indexer-grpc/indexer-grpc-server-framework",
+    # "ecosystem/indexer-grpc/indexer-grpc-table-info",
+    # "ecosystem/indexer-grpc/indexer-grpc-utils",
+    # "ecosystem/indexer-grpc/indexer-test-transactions",
+    # "ecosystem/indexer-grpc/indexer-transaction-generator",
+    # "ecosystem/indexer-grpc/transaction-filter",
+    # "ecosystem/nft-metadata-crawler-parser",
+    # "ecosystem/node-checker",
+    # "ecosystem/node-checker/fn-check-client",
     "execution/block-partitioner",
-    "execution/executor",
-    "execution/executor-benchmark",
-    "execution/executor-service",
+    # "execution/executor",
+    # "execution/executor-benchmark",
+    # "execution/executor-service",
     "execution/executor-test-helpers",
-    "execution/executor-types",
-    "experimental/execution/ptx-executor",
-    "experimental/runtimes",
-    "experimental/storage/hexy",
-    "experimental/storage/layered-map",
-    "keyless/circuit",
-    "keyless/common",
-    "keyless/pepper/common",
-    "keyless/pepper/example-client-rust",
-    "keyless/pepper/service",
+    # "execution/executor-types",
+    # "experimental/execution/ptx-executor",
+    # "experimental/runtimes",
+    # "experimental/storage/hexy",
+    # "experimental/storage/layered-map",
+    # "keyless/circuit",
+    # "keyless/common",
+    # "keyless/pepper/common",
+    # "keyless/pepper/example-client-rust",
+    # "keyless/pepper/service",
     "mempool",
-    "network/benchmark",
-    "network/builder",
-    "network/discovery",
-    "network/framework",
+    # "network/benchmark",
+    # "network/builder",
+    # "network/discovery",
+    # "network/framework",
     "network/memsocket",
     "network/netcore",
-    "peer-monitoring-service/client",
-    "peer-monitoring-service/server",
-    "peer-monitoring-service/types",
-    "protos/rust",
-    "sdk",
-    "secure/net",
-    "secure/storage",
-    "secure/storage/vault",
-    "state-sync/aptos-data-client",
-    "state-sync/data-streaming-service",
-    "state-sync/inter-component/consensus-notifications",
-    "state-sync/inter-component/event-notifications",
-    "state-sync/inter-component/mempool-notifications",
-    "state-sync/inter-component/storage-service-notifications",
-    "state-sync/state-sync-driver",
-    "state-sync/storage-service/client",
-    "state-sync/storage-service/server",
-    "state-sync/storage-service/types",
+    # "peer-monitoring-service/client",
+    # "peer-monitoring-service/server",
+    # "peer-monitoring-service/types",
+    # "protos/rust",
+    # "sdk",
+    # "secure/net",
+    # "secure/storage",
+    # "secure/storage/vault",
+    # "state-sync/aptos-data-client",
+    # "state-sync/data-streaming-service",
+    # "state-sync/inter-component/consensus-notifications",
+    # "state-sync/inter-component/event-notifications",
+    # "state-sync/inter-component/mempool-notifications",
+    # "state-sync/inter-component/storage-service-notifications",
+    # "state-sync/state-sync-driver",
+    # "state-sync/storage-service/client",
+    # "state-sync/storage-service/server",
+    # "state-sync/storage-service/types",
     "storage/accumulator",
-    "storage/aptosdb",
-    "storage/backup/backup-cli",
-    "storage/backup/backup-service",
-    "storage/db-tool",
-    "storage/executable-store",
+    # "storage/aptosdb",
+    # "storage/backup/backup-cli",
+    # "storage/backup/backup-service",
+    # "storage/db-tool",
+    # "storage/executable-store",
     "storage/indexer",
     "storage/indexer_schemas",
     "storage/jellyfish-merkle",
-    "storage/rocksdb-options",
-    "storage/schemadb",
+    # "storage/rocksdb-options",
+    # "storage/schemadb",
     "storage/scratchpad",
-    "storage/storage-interface",
-    "testsuite/forge",
-    "testsuite/forge-cli",
-    "testsuite/fuzzer",
-    "testsuite/fuzzer/fuzz",
-    "testsuite/generate-format",
-    "testsuite/module-publish",
-    "testsuite/smoke-test",
-    "testsuite/testcases",
+    # "storage/storage-interface",
+    # "testsuite/forge",
+    # "testsuite/forge-cli",
+    # "testsuite/fuzzer",
+    # "testsuite/fuzzer/fuzz",
+    # "testsuite/generate-format",
+    # "testsuite/module-publish",
+    # "testsuite/smoke-test",
+    # "testsuite/testcases",
     "third_party/move/evm/exec-utils",
     "third_party/move/evm/extract-ethereum-abi",
-    # third_party/move
+    # # third_party/move
     "third_party/move/extensions/async/move-async-vm",
     "third_party/move/extensions/move-table-extension",
     "third_party/move/move-binary-format",
@@ -209,8 +209,8 @@ members = [
     "third_party/move/move-compiler-v2/tools/testdiff",
     "third_party/move/move-compiler-v2/transactional-tests",
     "third_party/move/move-compiler/transactional-tests",
-    "third_party/move/move-core/types",
-    "third_party/move/move-examples",
+    # "third_party/move/move-core/types",
+    # "third_party/move/move-examples",
     "third_party/move/move-ir-compiler",
     "third_party/move/move-ir-compiler/move-bytecode-source-map",
     "third_party/move/move-ir-compiler/move-ir-to-bytecode",
@@ -238,19 +238,19 @@ members = [
     "third_party/move/testing-infra/module-generation",
     "third_party/move/testing-infra/test-generation",
     "third_party/move/testing-infra/transactional-test-runner",
-    "third_party/move/tools/move-bytecode-utils",
-    "third_party/move/tools/move-bytecode-viewer",
-    "third_party/move/tools/move-cli",
-    "third_party/move/tools/move-coverage",
-    "third_party/move/tools/move-disassembler",
-    "third_party/move/tools/move-explain",
-    "third_party/move/tools/move-package",
-    "third_party/move/tools/move-resource-viewer",
-    "third_party/move/tools/move-unit-test",
-    "tools/calc-dep-sizes",
-    "tools/compute-module-expansion-size",
-    "types",
-    "vm-validator",
+    # "third_party/move/tools/move-bytecode-utils",
+    # "third_party/move/tools/move-bytecode-viewer",
+    # "third_party/move/tools/move-cli",
+    # "third_party/move/tools/move-coverage",
+    # "third_party/move/tools/move-disassembler",
+    # "third_party/move/tools/move-explain",
+    # "third_party/move/tools/move-package",
+    # "third_party/move/tools/move-resource-viewer",
+    # "third_party/move/tools/move-unit-test",
+    # "tools/calc-dep-sizes",
+    # "tools/compute-module-expansion-size",
+    # "types",
+    # "vm-validator",
 ]
 
 # NOTE: default-members is the complete list of binaries that form the "production Aptos codebase". These members should
@@ -259,18 +259,18 @@ members = [
 #
 # For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
 default-members = [
-    "aptos-node",
-    "consensus/safety-rules",
-    "crates/aptos",
-    "crates/aptos-debugger",
-    "crates/aptos-faucet/service",
+    # "aptos-node",
+    # "consensus/safety-rules",
+    # "crates/aptos",
+    # "crates/aptos-debugger",
+    # "crates/aptos-faucet/service",
     "crates/aptos-keygen",
-    "crates/aptos-rate-limiter",
-    "crates/aptos-rosetta",
-    "crates/transaction-emitter",
-    "aptos-move/framework",
-    "storage/backup/backup-cli",
-    "ecosystem/node-checker",
+    # "crates/aptos-rate-limiter",
+    # "crates/aptos-rosetta",
+    # "crates/transaction-emitter",
+    # "aptos-move/framework",
+    # "storage/backup/backup-cli",
+    # "ecosystem/node-checker",
 ]
 
 # All workspace members should inherit these keys
@@ -287,15 +287,15 @@ rust-version = "1.78.0"
 [workspace.dependencies]
 # Internal crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
-aptos = { path = "crates/aptos" }
+# aptos = { path = "crates/aptos" }
 aptos-accumulator = { path = "storage/accumulator" }
-aptos-admin-service = { path = "crates/aptos-admin-service" }
+# aptos-admin-service = { path = "crates/aptos-admin-service" }
 aptos-aggregator = { path = "aptos-move/aptos-aggregator" }
 aptos-api = { path = "api" }
 aptos-api-test-context = { path = "api/test-context" }
 aptos-api-types = { path = "api/types" }
-aptos-backup-cli = { path = "storage/backup/backup-cli" }
-aptos-backup-service = { path = "storage/backup/backup-service" }
+# aptos-backup-cli = { path = "storage/backup/backup-cli" }
+# aptos-backup-service = { path = "storage/backup/backup-service" }
 aptos-bcs-utils = { path = "crates/aptos-bcs-utils" }
 aptos-bounded-executor = { path = "crates/bounded-executor" }
 aptos-block-executor = { path = "aptos-move/block-executor" }
@@ -303,46 +303,46 @@ aptos-bitvec = { path = "crates/aptos-bitvec" }
 aptos-build-info = { path = "crates/aptos-build-info" }
 aptos-cached-packages = { path = "aptos-move/framework/cached-packages" }
 aptos-channels = { path = "crates/channel" }
-aptos-cli-common = { path = "crates/aptos-cli-common" }
+# aptos-cli-common = { path = "crates/aptos-cli-common" }
 aptos-collections = { path = "crates/aptos-collections" }
 aptos-compression = { path = "crates/aptos-compression" }
-aptos-consensus = { path = "consensus" }
+# aptos-consensus = { path = "consensus" }
 aptos-consensus-notifications = { path = "state-sync/inter-component/consensus-notifications" }
 aptos-consensus-types = { path = "consensus/consensus-types" }
 aptos-config = { path = "config" }
-aptos-crash-handler = { path = "crates/crash-handler" }
+# aptos-crash-handler = { path = "crates/crash-handler" }
 aptos-crypto = { path = "crates/aptos-crypto" }
 aptos-crypto-derive = { path = "crates/aptos-crypto-derive" }
-aptos-data-client = { path = "state-sync/aptos-data-client" }
-aptos-data-streaming-service = { path = "state-sync/data-streaming-service" }
+# aptos-data-client = { path = "state-sync/aptos-data-client" }
+# aptos-data-streaming-service = { path = "state-sync/data-streaming-service" }
 aptos-db = { path = "storage/aptosdb" }
 aptos-db-indexer = { path = "storage/indexer" }
 aptos-db-indexer-schemas = { path = "storage/indexer_schemas" }
-aptos-db-tool = { path = "storage/db-tool" }
-aptos-debugger = { path = "crates/aptos-debugger" }
+# aptos-db-tool = { path = "storage/db-tool" }
+# aptos-debugger = { path = "crates/aptos-debugger" }
 aptos-dkg = { path = "crates/aptos-dkg" }
-aptos-dkg-runtime = { path = "dkg" }
+# aptos-dkg-runtime = { path = "dkg" }
 aptos-drop-helper = { path = "crates/aptos-drop-helper" }
 aptos-event-notifications = { path = "state-sync/inter-component/event-notifications" }
-aptos-executable-store = { path = "storage/executable-store" }
+# aptos-executable-store = { path = "storage/executable-store" }
 aptos-executor = { path = "execution/executor" }
 aptos-block-partitioner = { path = "execution/block-partitioner" }
 aptos-enum-conversion-derive = { path = "crates/aptos-enum-conversion-derive" }
 aptos-executor-service = { path = "execution/executor-service" }
 aptos-executor-test-helpers = { path = "execution/executor-test-helpers" }
 aptos-executor-types = { path = "execution/executor-types" }
-aptos-experimental-hexy = { path = "experimental/storage/hexy" }
-aptos-experimental-layered-map = { path = "experimental/storage/layered-map" }
-aptos-experimental-ptx-executor = { path = "experimental/execution/ptx-executor" }
+# aptos-experimental-hexy = { path = "experimental/storage/hexy" }
+# aptos-experimental-layered-map = { path = "experimental/storage/layered-map" }
+# aptos-experimental-ptx-executor = { path = "experimental/execution/ptx-executor" }
 aptos-experimental-runtimes = { path = "experimental/runtimes" }
-aptos-faucet-cli = { path = "crates/aptos-faucet/cli" }
-aptos-faucet-core = { path = "crates/aptos-faucet/core" }
-aptos-faucet-service = { path = "crates/aptos-faucet/service" }
-aptos-faucet-metrics-server = { path = "crates/aptos-faucet/metrics-server" }
+# aptos-faucet-cli = { path = "crates/aptos-faucet/cli" }
+# aptos-faucet-core = { path = "crates/aptos-faucet/core" }
+# aptos-faucet-service = { path = "crates/aptos-faucet/service" }
+# aptos-faucet-metrics-server = { path = "crates/aptos-faucet/metrics-server" }
 aptos-fallible = { path = "crates/fallible" }
-aptos-forge = { path = "testsuite/forge" }
+# aptos-forge = { path = "testsuite/forge" }
 aptos-framework = { path = "aptos-move/framework" }
-fuzzer = { path = "testsuite/fuzzer" }
+# fuzzer = { path = "testsuite/fuzzer" }
 aptos-abstract-gas-usage = { path = "aptos-move/aptos-abstract-gas-usage" }
 aptos-gas-meter = { path = "aptos-move/aptos-gas-meter" }
 aptos-gas-algebra = { path = "aptos-move/aptos-gas-algebra" }
@@ -351,26 +351,26 @@ aptos-gas-profiling = { path = "aptos-move/aptos-gas-profiling" }
 aptos-gas-schedule = { path = "aptos-move/aptos-gas-schedule" }
 aptos-gas-schedule-updator = { path = "aptos-move/aptos-gas-schedule-updator" }
 aptos-genesis = { path = "crates/aptos-genesis" }
-aptos-github-client = { path = "crates/aptos-github-client" }
+# aptos-github-client = { path = "crates/aptos-github-client" }
 aptos-global-constants = { path = "config/global-constants" }
 aptos-id-generator = { path = "crates/aptos-id-generator" }
-aptos-indexer = { path = "crates/indexer" }
-aptos-indexer-grpc-cache-worker = { path = "ecosystem/indexer-grpc/indexer-grpc-cache-worker" }
-aptos-indexer-grpc-data-service = { path = "ecosystem/indexer-grpc/indexer-grpc-data-service" }
-aptos-indexer-grpc-file-store = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store" }
-aptos-indexer-grpc-file-store-backfiller = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller" }
+# aptos-indexer = { path = "crates/indexer" }
+# aptos-indexer-grpc-cache-worker = { path = "ecosystem/indexer-grpc/indexer-grpc-cache-worker" }
+# aptos-indexer-grpc-data-service = { path = "ecosystem/indexer-grpc/indexer-grpc-data-service" }
+# aptos-indexer-grpc-file-store = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store" }
+# aptos-indexer-grpc-file-store-backfiller = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller" }
 aptos-indexer-grpc-fullnode = { path = "ecosystem/indexer-grpc/indexer-grpc-fullnode" }
-aptos-indexer-grpc-in-memory-cache-benchmark = { path = "ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark" }
+# aptos-indexer-grpc-in-memory-cache-benchmark = { path = "ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark" }
 aptos-indexer-grpc-table-info = { path = "ecosystem/indexer-grpc/indexer-grpc-table-info" }
-aptos-indexer-test-transactions = { path = "ecosystem/indexer-grpc/indexer-test-transactions" }
+# aptos-indexer-test-transactions = { path = "ecosystem/indexer-grpc/indexer-test-transactions" }
 aptos-indexer-grpc-utils = { path = "ecosystem/indexer-grpc/indexer-grpc-utils" }
-aptos-indexer-grpc-server-framework = { path = "ecosystem/indexer-grpc/indexer-grpc-server-framework" }
-aptos-indexer-transaction-generator = { path = "ecosystem/indexer-grpc/indexer-transaction-generator" }
+# aptos-indexer-grpc-server-framework = { path = "ecosystem/indexer-grpc/indexer-grpc-server-framework" }
+# aptos-indexer-transaction-generator = { path = "ecosystem/indexer-grpc/indexer-transaction-generator" }
 aptos-infallible = { path = "crates/aptos-infallible" }
-aptos-inspection-service = { path = "crates/aptos-inspection-service" }
+# aptos-inspection-service = { path = "crates/aptos-inspection-service" }
 aptos-jellyfish-merkle = { path = "storage/jellyfish-merkle" }
-aptos-jwk-consensus = { path = "crates/aptos-jwk-consensus" }
-aptos-jwk-utils = { path = "crates/jwk-utils" }
+# aptos-jwk-consensus = { path = "crates/aptos-jwk-consensus" }
+# aptos-jwk-utils = { path = "crates/jwk-utils" }
 aptos-keygen = { path = "crates/aptos-keygen" }
 aptos-language-e2e-tests = { path = "aptos-move/e2e-tests" }
 aptos-ledger = { path = "crates/aptos-ledger" }
@@ -381,44 +381,44 @@ aptos-mempool = { path = "mempool" }
 aptos-mempool-notifications = { path = "state-sync/inter-component/mempool-notifications" }
 aptos-memsocket = { path = "network/memsocket" }
 aptos-metrics-core = { path = "crates/aptos-metrics-core" }
-aptos-move-debugger = { path = "aptos-move/aptos-debugger" }
-aptos-move-examples = { path = "aptos-move/move-examples" }
-aptos-move-e2e-benchmark = { path = "aptos-move/e2e-benchmark" }
+# aptos-move-debugger = { path = "aptos-move/aptos-debugger" }
+# aptos-move-examples = { path = "aptos-move/move-examples" }
+# aptos-move-e2e-benchmark = { path = "aptos-move/e2e-benchmark" }
 aptos-mvhashmap = { path = "aptos-move/mvhashmap" }
 aptos-native-interface = { path = "aptos-move/aptos-native-interface" }
 aptos-netcore = { path = "network/netcore" }
 aptos-network = { path = "network/framework" }
-aptos-network-benchmark = { path = "network/benchmark" }
-aptos-network-builder = { path = "network/builder" }
-aptos-network-checker = { path = "crates/aptos-network-checker" }
-aptos-network-discovery = { path = "network/discovery" }
-aptos-nft-metadata-crawler-parser = { path = "ecosystem/nft-metadata-crawler-parser" }
-aptos-node = { path = "aptos-node" }
-aptos-node-checker = { path = "ecosystem/node-checker" }
+# aptos-network-benchmark = { path = "network/benchmark" }
+# aptos-network-builder = { path = "network/builder" }
+# aptos-network-checker = { path = "crates/aptos-network-checker" }
+# aptos-network-discovery = { path = "network/discovery" }
+# aptos-nft-metadata-crawler-parser = { path = "ecosystem/nft-metadata-crawler-parser" }
+# aptos-node = { path = "aptos-node" }
+# aptos-node-checker = { path = "ecosystem/node-checker" }
 aptos-node-identity = { path = "crates/aptos-node-identity" }
 aptos-node-resource-metrics = { path = "crates/node-resource-metrics" }
 aptos-num-variants = { path = "crates/num-variants" }
 aptos-openapi = { path = "crates/aptos-openapi" }
 aptos-package-builder = { path = "aptos-move/package-builder" }
-aptos-peer-monitoring-service-client = { path = "peer-monitoring-service/client" }
-aptos-peer-monitoring-service-server = { path = "peer-monitoring-service/server" }
+# aptos-peer-monitoring-service-client = { path = "peer-monitoring-service/client" }
+# aptos-peer-monitoring-service-server = { path = "peer-monitoring-service/server" }
 aptos-peer-monitoring-service-types = { path = "peer-monitoring-service/types" }
-aptos-keyless-common = { path = "keyless/common" }
-aptos-keyless-pepper-common = { path = "keyless/pepper/common" }
-aptos-keyless-pepper-service = { path = "keyless/pepper/service" }
-aptos-profiler = { path = "crates/aptos-profiler" }
+# aptos-keyless-common = { path = "keyless/common" }
+# aptos-keyless-pepper-common = { path = "keyless/pepper/common" }
+# aptos-keyless-pepper-service = { path = "keyless/pepper/service" }
+# aptos-profiler = { path = "crates/aptos-profiler" }
 aptos-proptest-helpers = { path = "crates/aptos-proptest-helpers" }
 aptos-protos = { path = "protos/rust" }
 aptos-proxy = { path = "crates/proxy" }
 aptos-push-metrics = { path = "crates/aptos-push-metrics" }
-aptos-rate-limiter = { path = "crates/aptos-rate-limiter" }
-aptos-release-builder = { path = "aptos-move/aptos-release-builder" }
+# aptos-rate-limiter = { path = "crates/aptos-rate-limiter" }
+# aptos-release-builder = { path = "aptos-move/aptos-release-builder" }
 aptos-reliable-broadcast = { path = "crates/reliable-broadcast" }
 aptos-resource-viewer = { path = "aptos-move/aptos-resource-viewer" }
 aptos-rest-client = { path = "crates/aptos-rest-client" }
-aptos-retrier = { path = "crates/aptos-retrier" }
+# aptos-retrier = { path = "crates/aptos-retrier" }
 aptos-rocksdb-options = { path = "storage/rocksdb-options" }
-aptos-rosetta = { path = "crates/aptos-rosetta" }
+# aptos-rosetta = { path = "crates/aptos-rosetta" }
 aptos-runtimes = { path = "crates/aptos-runtimes" }
 aptos-safety-rules = { path = "consensus/safety-rules" }
 aptos-schemadb = { path = "storage/schemadb" }
@@ -429,27 +429,25 @@ aptos-secure-net = { path = "secure/net" }
 aptos-secure-storage = { path = "secure/storage" }
 aptos-short-hex-str = { path = "crates/short-hex-str" }
 aptos-speculative-state-helper = { path = "crates/aptos-speculative-state-helper" }
-aptos-state-sync-driver = { path = "state-sync/state-sync-driver" }
+# aptos-state-sync-driver = { path = "state-sync/state-sync-driver" }
 aptos-storage-interface = { path = "storage/storage-interface" }
-aptos-storage-service-client = { path = "state-sync/storage-service/client" }
-aptos-storage-service-notifications = { path = "state-sync/inter-component/storage-service-notifications" }
-aptos-storage-service-types = { path = "state-sync/storage-service/types" }
-aptos-storage-service-server = { path = "state-sync/storage-service/server" }
-aptos-system-utils = { path = "crates/aptos-system-utils" }
-aptos-transaction-filter = { path = "ecosystem/indexer-grpc/transaction-filter" }
-aptos-telemetry = { path = "crates/aptos-telemetry" }
-aptos-telemetry-service = { path = "crates/aptos-telemetry-service" }
+# aptos-storage-service-client = { path = "state-sync/storage-service/client" }
+# aptos-storage-service-notifications = { path = "state-sync/inter-component/storage-service-notifications" }
+# aptos-storage-service-types = { path = "state-sync/storage-service/types" }
+# aptos-storage-service-server = { path = "state-sync/storage-service/server" }
+# aptos-system-utils = { path = "crates/aptos-system-utils" }
+# aptos-transaction-filter = { path = "ecosystem/indexer-grpc/transaction-filter" }
+# aptos-telemetry = { path = "crates/aptos-telemetry" }
+# aptos-telemetry-service = { path = "crates/aptos-telemetry-service" }
 aptos-temppath = { path = "crates/aptos-temppath" }
-aptos-testcases = { path = "testsuite/testcases" }
-aptos-time-service = { path = "crates/aptos-time-service", features = [
-    "async",
-] }
-aptos-transaction-emitter-lib = { path = "crates/transaction-emitter-lib" }
-aptos-transaction-generator-lib = { path = "crates/transaction-generator-lib" }
-aptos-transactional-test-harness = { path = "aptos-move/aptos-transactional-test-harness" }
+# aptos-testcases = { path = "testsuite/testcases" }
+aptos-time-service = { path = "crates/aptos-time-service", features = [    "async",] }
+# aptos-transaction-emitter-lib = { path = "crates/transaction-emitter-lib" }
+# aptos-transaction-generator-lib = { path = "crates/transaction-generator-lib" }
+# aptos-transactional-test-harness = { path = "aptos-move/aptos-transactional-test-harness" }
 aptos-types = { path = "types" }
 aptos-utils = { path = "aptos-utils" }
-aptos-validator-interface = { path = "aptos-move/aptos-validator-interface" }
+# aptos-validator-interface = { path = "aptos-move/aptos-validator-interface" }
 aptos-validator-transaction-pool = { path = "crates/validator-transaction-pool" }
 aptos-vault-client = { path = "secure/storage/vault" }
 aptos-vm = { path = "aptos-move/aptos-vm" }
@@ -457,19 +455,19 @@ aptos-vm-logging = { path = "aptos-move/aptos-vm-logging" }
 aptos-vm-genesis = { path = "aptos-move/vm-genesis" }
 aptos-vm-types = { path = "aptos-move/aptos-vm-types" }
 aptos-vm-validator = { path = "vm-validator" }
-aptos-warp-webserver = { path = "crates/aptos-warp-webserver" }
-aptos-cargo-cli = { path = "devtools/aptos-cargo-cli" }
+# aptos-warp-webserver = { path = "crates/aptos-warp-webserver" }
+# aptos-cargo-cli = { path = "devtools/aptos-cargo-cli" }
 
 # External crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
 aes-gcm = "0.10.3"
 ahash = "0.8.11"
 atty = "0.2.14"
-nalgebra = "0.32"
-float-cmp = "0.9.0"
-again = "0.1.2"
+# nalgebra = "0.32"
+# float-cmp = "0.9.0"
+# again = "0.1.2"
 anyhow = "1.0.71"
-anstyle = "1.0.1"
+# anstyle = "1.0.1"
 arbitrary = { version = "1.3.2", features = ["derive"] }
 arc-swap = "1.6.0"
 arr_macro = "0.2.1"
@@ -481,36 +479,36 @@ ark-groth16 = "0.4.0"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", features = ["getrandom"] }
 aptos-moving-average = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf" }
-assert_approx_eq = "1.1.0"
+# assert_approx_eq = "1.1.0"
 assert_unordered = "0.3.5"
-async-channel = "1.7.1"
-async-mutex = "1.4.0"
-async-recursion = "1.0.5"
-async-stream = "0.3"
+# async-channel = "1.7.1"
+# async-mutex = "1.4.0"
+# async-recursion = "1.0.5"
+# async-stream = "0.3"
 async-trait = "0.1.53"
-axum = "0.7.5"
+# axum = "0.7.5"
 base64 = "0.13.0"
-base64-url = "2.0.1"
+# base64-url = "2.0.1"
 backoff = { version = "0.4.0", features = ["tokio"] }
 backtrace = "0.3.58"
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 better_any = "0.1.1"
-bellman = { version = "0.13.1", default-features = false }
-bigdecimal = { version = "0.4.0", features = ["serde"] }
-version-compare = "0.1.1"
+# bellman = { version = "0.13.1", default-features = false }
+# bigdecimal = { version = "0.4.0", features = ["serde"] }
+# version-compare = "0.1.1"
 bitvec = "1.0.1"
 blake2 = "0.10.4"
 blake2-rfc = "0.2.18"
 blst = "0.3.11"
 # The __private_bench feature exposes the Fp12 type which we need to implement a multi-threaded multi-pairing.
 blstrs = { version = "0.7.1", features = ["serde", "__private_bench"] }
-bollard = "0.15"
+# bollard = "0.15"
 bulletproofs = { version = "4.0.0" }
 byteorder = "1.4.3"
 bytes = { version = "1.4.0", features = ["serde"] }
-camino = { version = "1.1.6" }
+# camino = { version = "1.1.6" }
 chrono = { version = "0.4.19", features = ["clock", "serde"] }
-cfg_block = "0.1.1"
+# cfg_block = "0.1.1"
 cfg-if = "1.0.0"
 ciborium = "0.2"
 claims = "0.7"
@@ -526,57 +524,57 @@ codespan-reporting = "0.11.1"
 colored = "2.0.0"
 concurrent-queue = "2.2.0"
 console-subscriber = "0.3.0"
-const_format = "0.2.26"
+# const_format = "0.2.26"
 core_affinity = "0.8.1"
 coset = "0.3"
 criterion = "0.3.5"
-criterion-cpu-time = "0.1.0"
+# criterion-cpu-time = "0.1.0"
 crossbeam = "0.8.1"
 crossbeam-channel = "0.5.4"
 crossterm = "0.26.1"
-csv = "1.2.1"
+# csv = "1.2.1"
 curve25519-dalek = "3"
 curve25519-dalek-ng = "4"
 dashmap = { version = "5.5.3", features = ["inline"] }
 datatest-stable = "0.1.1"
-debug-ignore = { version = "1.0.3", features = ["serde"] }
+# debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"
-derivation-path = "0.2.0"
-derive_builder = "0.20.0"
-determinator = "0.12.0"
+# derivation-path = "0.2.0"
+# derive_builder = "0.20.0"
+# determinator = "0.12.0"
 derive_more = "0.99.11"
-diesel = "2.1"
+# diesel = "2.1"
 # Use the crate version once this feature gets released on crates.io:
 # https://github.com/weiznich/diesel_async/commit/e165e8c96a6c540ebde2d6d7c52df5c5620a4bf1
-diesel-async = { git = "https://github.com/weiznich/diesel_async.git", rev = "d02798c67065d763154d7272dd0c09b39757d0f2", features = [
-    "async-connection-wrapper",
-    "postgres",
-    "bb8",
-    "tokio",
-] }
-diesel_migrations = { version = "2.1.0", features = ["postgres"] }
+# diesel-async = { git = "https://github.com/weiznich/diesel_async.git", rev = "d02798c67065d763154d7272dd0c09b39757d0f2", features = [
+#     "async-connection-wrapper",
+#     "postgres",
+#     "bb8",
+#     "tokio",
+# ] }
+# diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 difference = "2.0.0"
 digest = "0.9.0"
 dir-diff = "0.3.2"
-dirs = "5.0.1"
+# dirs = "5.0.1"
 dirs-next = "2.0.0"
 dunce = "1.0.4"
 ed25519-dalek = { version = "1.0.1", features = ["std", "serde"] }
 ed25519-dalek-bip32 = "0.2.0"
 either = "1.6.1"
 enum_dispatch = "0.3.12"
-env_logger = "0.10.0"
+# env_logger = "0.10.0"
 erased-serde = "0.3.13"
 ethabi = "18.0.0"
 ethnum = "1.5.0"
-event-listener = "2.5.3"
+# event-listener = "2.5.3"
 evm = { version = "0.33.1", features = ["tracing"] }
 evm-runtime = { version = "0.33.0", features = ["tracing"] }
 fail = "0.5.0"
 ff = { version = "0.13", features = ["derive"] }
-field_count = "0.1.1"
+# field_count = "0.1.1"
 file_diff = "1.0.0"
-firestore = "0.43.0"
+# firestore = "0.43.0"
 fixed = "1.25.1"
 flate2 = "1.0.24"
 flexi_logger = "0.27.4"
@@ -586,29 +584,29 @@ futures-core = "0.3.29"
 futures-util = "0.3.29"
 fxhash = "0.2.1"
 getrandom = "0.2.2"
-gcp-bigquery-client = "0.16.8"
+# gcp-bigquery-client = "0.16.8"
 get_if_addrs = "0.5.3"
-git2 = "0.16.1"
-glob = "0.3.0"
+# git2 = "0.16.1"
+# glob = "0.3.0"
 goldenfile = "1.5.2"
 google-cloud-storage = "0.13.0"
 group = "0.13"
-guppy = "0.17.5"
+# guppy = "0.17.5"
 handlebars = "4.2.2"
 hashbrown = "0.14.3"
 heck = "0.4.1"
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.3.4"
 hkdf = "0.10.0"
-hmac = "0.12.0"
+# hmac = "0.12.0"
 hostname = "0.3.1"
-http = "0.2.9"
+# http = "0.2.9"
 httpmock = "0.6.8"
 hyper = { version = "0.14.18", features = ["full"] }
-hyper-tls = "0.5.0"
-image = "0.24.5"
+# hyper-tls = "0.5.0"
+# image = "0.24.5"
 indexmap = "1.9.3"
-include_dir = { version = "0.7.2", features = ["glob"] }
+# include_dir = { version = "0.7.2", features = ["glob"] }
 indicatif = "0.15.0"
 indoc = "1.0.6"
 inferno = "0.11.14"
@@ -619,10 +617,10 @@ jemallocator = { version = "0.5.0", features = [
     "profiling",
     "unprefixed_malloc_on_supported_platforms",
 ] }
-jemalloc-sys = "0.5.4"
-json-patch = "0.2.6"
+# jemalloc-sys = "0.5.4"
+# json-patch = "0.2.6"
 jsonwebtoken = "8.1"
-jwt = "0.16.0"
+# jwt = "0.16.0"
 lazy_static = "1.4.0"
 libc = "0.2.147"
 libfuzzer-sys = "0.4.6"
@@ -641,7 +639,7 @@ more-asserts = "0.3.0"
 named-lock = "0.2.0"
 native-tls = "0.2.10"
 neptune = { version = "13.0.0", default_features = false }
-ntest = "0.9.0"
+# ntest = "0.9.0"
 num = "0.4.0"
 num-bigint = { version = "0.3.2", features = ["rand"] }
 num_cpus = "1.13.1"
@@ -656,11 +654,11 @@ p256 = { version = "0.13.2" }
 prettydiff = "0.6.2"
 primitive-types = { version = "0.10" }
 signature = "2.1.0"
-sec1 = "0.7.0"
+# sec1 = "0.7.0"
 pairing = "0.23"
 parking_lot = "0.12.0"
 paste = "1.0.7"
-pathsearch = "0.2.0"
+# pathsearch = "0.2.0"
 passkey-authenticator = { version = "0.2.0", features = ["testable"] }
 passkey-client = { version = "0.2.0" }
 passkey-types = { version = "0.2.0" }
@@ -674,25 +672,25 @@ poem = { git = "https://github.com/poem-web/poem.git", rev = "809b2816d3504beeba
 poem-openapi = { git = "https://github.com/poem-web/poem.git", rev = "809b2816d3504beeba140fef3fdfe9432d654c5b", features = ["swagger-ui", "url"] }
 poem-openapi-derive = { git = "https://github.com/poem-web/poem.git", rev = "809b2816d3504beeba140fef3fdfe9432d654c5b" }
 poseidon-ark = { git = "https://github.com/arnaucube/poseidon-ark.git", rev = "6d2487aa1308d9d3860a2b724c485d73095c1c68" }
-pprof = { version = "0.11", features = ["flamegraph", "protobuf-codec"] }
+# pprof = { version = "0.11", features = ["flamegraph", "protobuf-codec"] }
 pretty = "0.10.0"
 pretty_assertions = "1.2.1"
 procfs = "0.14.1"
 proc-macro2 = "1.0.38"
-project-root = "0.2.2"
+# project-root = "0.2.2"
 prometheus = { version = "0.13.3", default-features = false }
-prometheus-http-query = "0.5.2"
-prometheus-parse = "0.2.4"
+# prometheus-http-query = "0.5.2"
+# prometheus-parse = "0.2.4"
 proptest = "1.4.0"
 proptest-derive = "0.4.0"
 prost = { version = "0.12.3", features = ["no-recursion-limit"] }
-prost-types = "0.12.3"
-quanta = "0.10.1"
+# prost-types = "0.12.3"
+# quanta = "0.10.1"
 quick_cache = "0.5.1"
 quote = "1.0.18"
 rand = "0.7.3"
 rand_core = "0.5.1"
-random_word = "0.3.0"
+# random_word = "0.3.0"
 rayon = "1.5.2"
 redis = { version = "0.22.3", features = [
     "tokio-comp",
@@ -712,20 +710,20 @@ reqwest = { version = "0.11.11", features = [
 async-std = "1.10.0"
 tide = "0.16"
 surf = "2.3"
-reqwest-middleware = "0.2.0"
-reqwest-retry = "0.2.1"
+# reqwest-middleware = "0.2.0"
+# reqwest-retry = "0.2.1"
 ring = { version = "0.16.20", features = ["std"] }
 ripemd = "0.1.1"
 rocksdb = { version = "0.22.0", features = ["lz4"] }
 rsa = { version = "0.9.6" }
-rstack-self = { version = "0.3.0", features = ["dw"], default_features = false }
-rstest = "0.15.0"
+# rstack-self = { version = "0.3.0", features = ["dw"], default_features = false }
+# rstest = "0.15.0"
 rusty-fork = "0.3.0"
 rustversion = "1.0.14"
 scopeguard = "1.2.0"
-sha-1 = "0.10.0"
+# sha-1 = "0.10.0"
 sha2 = "0.9.3"
-sha256 = "1.4.0"
+# sha256 = "1.4.0"
 sha2_0_10_6 = { package = "sha2", version = "0.10.6" }
 sha3 = "0.9.1"
 shell-words = "1.0.0"
@@ -737,7 +735,7 @@ serde_json = { version = "1.0.81", features = [
     "preserve_order",
     "arbitrary_precision",
 ] } # Note: arbitrary_precision is required to parse u256 in JSON
-serde_repr = "0.1"
+# serde_repr = "0.1"
 serde_merge = "0.1.3"
 serde-name = "0.1.1"
 serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
@@ -749,7 +747,7 @@ simplelog = "0.9.0"
 smallbitvec = "2.5.1"
 smallvec = "1.8.0"
 static_assertions = "1.1.0"
-stats_alloc = "0.1.8"
+# stats_alloc = "0.1.8"
 status-line = "0.2.0"
 strum = "0.24.1"
 strum_macros = "0.24.2"
@@ -763,19 +761,19 @@ test-case = "3.1.0"
 textwrap = "0.15.0"
 thiserror = "1.0.37"
 threadpool = "1.8.1"
-thread_local = "1.1.7"
-time = { version = "0.3.24", features = ["serde"] }
+# thread_local = "1.1.7"
+# time = { version = "0.3.24", features = ["serde"] }
 tiny-bip39 = "0.8.2"
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
-toml_edit = "0.14.3"
+# toml_edit = "0.14.3"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 trybuild = "1.0.80"
 tokio = { version = "1.35.1", features = ["full"] }
-tokio-io-timeout = "1.2.0"
-tokio-metrics = "0.3.1"
+# tokio-io-timeout = "1.2.0"
+# tokio-metrics = "0.3.1"
 tokio-retry = "0.3.0"
-tokio-scoped = { version = "0.2.0" }
+# tokio-scoped = { version = "0.2.0" }
 tokio-stream = { version = "0.1.14", features = ["fs"] }
 tokio-test = "0.4.1"
 tokio-util = { version = "0.7.2", features = ["compat", "codec"] }
@@ -799,7 +797,7 @@ ureq = { version = "1.5.4", features = [
     "native-tls",
 ], default_features = false }
 url = { version = "2.4.0", features = ["serde"] }
-uuid = { version = "1.0.0", features = ["v4", "serde"] }
+# uuid = { version = "1.0.0", features = ["v4", "serde"] }
 variant_count = "1.1.0"
 walkdir = "2.3.3"
 warp = { version = "0.3.5", features = ["tls"] }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -50,8 +50,8 @@ aptos-validator-transaction-pool = { workspace = true }
 aptos-vm = { workspace = true }
 async-trait = { workspace = true }
 async-std = { workspace = true }
-tide = { workspace = true }
 surf = { workspace = true }
+# tide = { workspace = true } # TODO this package creates unfortunately a circular dependency warning, thus commented it out for now. However block_service has broken functionality without it.
 bcs = { workspace = true }
 byteorder = { workspace = true }
 bytes = { workspace = true }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -49,6 +49,9 @@ aptos-types = { workspace = true }
 aptos-validator-transaction-pool = { workspace = true }
 aptos-vm = { workspace = true }
 async-trait = { workspace = true }
+async-std = { workspace = true }
+tide = { workspace = true }
+surf = { workspace = true }
 bcs = { workspace = true }
 byteorder = { workspace = true }
 bytes = { workspace = true }
@@ -73,6 +76,7 @@ once_cell = { workspace = true }
 ordered-float = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
+reqwest = { workspace = true }
 scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
@@ -84,6 +88,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-retry = { workspace = true }
 tokio-stream = { workspace = true }
+warp = { workspace = true }
 
 [dev-dependencies]
 aptos-cached-packages = { workspace = true }

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -41,7 +41,6 @@ impl QuorumCert {
         }
     }
 
-    #[cfg(any(test, feature = "fuzzing"))]
     pub fn dummy() -> Self {
         Self {
             vote_data: VoteData::dummy(),

--- a/consensus/src/block_service_test.rs
+++ b/consensus/src/block_service_test.rs
@@ -1,0 +1,189 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::consensus_observer::observer::block_service::{start_block_service_with_tokio, start_block_service_with_tide, OrderedBlockClient};
+use crate::consensus_observer::observer::ordered_blocks::OrderedBlockStore;
+use reqwest;
+use async_std::task;
+use surf;
+
+
+/// This test function verifies the functionality of the ordered-block service client,
+/// by checking if it can fetch the latest block from the block store and the REST API endpoint.
+
+#[test]
+fn test_block_service_client_with_tide() {
+    // Run the async test using async-std
+    task::block_on(async {
+        // Step 1: Initialize the OrderedBlockStore
+        println!("\n - - - - - - - - - \n - - - - - - - - - Step 1: Initializing the OrderedBlockStore");
+        let ordered_block_store = OrderedBlockStore::new(Default::default());
+
+        // Step 2: Start the block service in a separate async task
+        println!("\n - - - - - - - - - \n - - - - - - - - - Step 2: Starting the block service in a separate task");
+        let ordered_block_store_clone = ordered_block_store.clone();
+        task::spawn(async move {
+            start_block_service_with_tide(ordered_block_store_clone).await;
+        });
+
+        // Step 3: Delay to ensure the block service has time to start
+        println!("\n - - - - - - - - - \n - - - - - - - - - Step 3: Delaying to ensure the block service has time to start");
+        task::sleep(std::time::Duration::from_secs(10)).await;
+
+        // Step 4.2: Check if the block service is running by sending a request
+        println!("\n - - - - - - - - - \n - - - - - - - - - Step 4: Checking that the block service is running via API");
+        let health_check_url = "http://127.0.0.1:3030/health";
+        match surf::get(health_check_url).await {
+            Ok(response) => {
+                assert!(response.status() == 200, "Block service health check failed");
+            }
+            Err(err) => {
+                panic!("\nFailed to connect to block service: {}", err);
+            }
+        }
+
+        // Step 5: Create the OrderedBlockClient
+        println!("\n - - - - - - - - - \n - - - - - - - - - Step 5: Creating the OrderedBlockClient");
+        let client = OrderedBlockClient::new(ordered_block_store);
+
+          // Step 5.1: Check if the block service is running by accessing the block store directly via the client
+        println!("\n - - - - - - - - - \n - - - - - - - - - Step 5.1: Checking that the block store is accessible via the client");
+        let last_block = client.get_last_ordered_block();
+        if let Some(block_info) = last_block {
+            println!("\n - - - - - - - - - \n - - - - - - - - - Last ordered block: {:?}", block_info);
+        } else {
+            println!("\n - - - - - - - - - \n - - - - - - - - - No blocks found in the store.");
+        }
+
+        // Step 6: Insert some blocks into the OrderedBlockStore for testing
+        println!("\n - - - - - - - - - \n - - - - - - - - - Step 6: Inserting blocks into the OrderedBlockStore and check its accessible via the client.");
+        let epoch = 0;
+        for round in 1..=3 {
+            println!("Inserting block for epoch {}, round {}", epoch, round);
+            let insert_success = client.insert_dummy_block(epoch, round).await;
+            if !insert_success {
+                panic!("\n - - - - - - - - - \n - - - - - - - - - Failed to insert dummy block for epoch {}, round {}", epoch, round);
+            }
+            let last_block = client.get_last_ordered_block();
+            if let Some(block_info) = last_block {
+                println!("\n - - - - - - - - - \n - - - - - - - - - Last ordered block: {:?}", block_info);
+            } else {
+                println!("\n - - - - - - - - - \n - - - - - - - - - No blocks found in the store.");
+            }
+        }
+
+
+        // Step 7: Fetch the latest block using the client and assert the block was retrieved successfully
+        println!("\n - - - - - - - - - \n - - - - - - - - - Step 7: Fetching the latest block using the client directly");
+        let round = 2;
+        let latest_block = client.get_block_by_round(epoch, round);
+        if let Some(block) = &latest_block {
+            println!("Block: {:?}", block);
+            assert_eq!(block["epoch"], epoch);
+            assert_eq!(block["round"], round);
+        } else {
+            panic!("\n - - - - - - - - - \n - - - - - - - - - Block not found");
+        }
+
+        // Step 8: Send a request to the REST API endpoint to verify the inserted block
+        println!("\n - - - - - - - - - \n - - - - - - - - - Step 8: Sending request to the REST API endpoint for epoch {}, round {}", epoch, round);
+        let api_url = format!("http://127.0.0.1:3030/blocks/{}/{}", epoch, round);
+        let mut response = surf::get(&api_url).await.unwrap();
+        assert!(response.status() == 200);
+        println!("Response status: {}", response.status());
+
+        let response_body: serde_json::Value = response.body_json().await.unwrap();
+        assert_eq!(response_body["epoch"], epoch);
+        assert_eq!(response_body["round"], round);
+        println!("Response body: {:?}", response_body);
+    });
+}
+
+
+
+
+// This test does not work. The error is
+// "Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted
+// to block the current thread while the thread is being used to drive asynchronous tasks."
+#[tokio::test]
+async fn test_block_service_client_tokio() {
+    // Step 1: Initialize the runtime and OrderedBlockStore
+    println!("\n - - - - - - - - - \n - - - - - - - - - Step 1: Initializing the runtime and OrderedBlockStore");
+    let ordered_block_store = OrderedBlockStore::new(Default::default());
+
+    // Step 2: Start the block service in a separate task
+    // We cannot start a runtime from within a runtime. Hence we cannot call start_block_service with await.
+    // Therefore we add a delay to ensure the block service has time to start before making requests to it.
+    println!("\n - - - - - - - - - \n - - - - - - - - - Step 2: Starting the block service in a separate task");
+    let ordered_block_store_clone = ordered_block_store.clone();
+    tokio::spawn(async move {
+        start_block_service_with_tokio(ordered_block_store_clone);
+    });
+
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // Step 2.1: Check that the block service is running by making a request to the health check endpoint
+    // We cannot start a runtime from within a runtime. Hence we cannot call client.get with await.
+    // Therefore we add a delay to ensure the block service has time to start before making requests to it.
+    println!("\n - - - - - - - - - \n - - - - - - - - - Step 2.1: Checking that the block service is running");
+    let health_check_url = "http://127.0.0.1:3030/health";
+    let client = reqwest::Client::new(); // Create a new reqwest client
+    println!("\n - - - - - - - - - \n - - - - - - - - - Sending health check request to block service");
+
+    // Send the HTTP request asynchronously
+    let health_check_url = health_check_url.to_string(); // Clone the URL to move it into the blocking task
+    let response = tokio::task::spawn_blocking(move || {
+        // Create a new runtime within this blocking task
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        // Run the async request within this newly created runtime
+        rt.block_on(async {
+            client.get(&health_check_url).send().await
+        })
+    }).await.unwrap();
+
+    match response {
+        Ok(response) => {
+            assert!(response.status().is_success(), "Block service health check failed");
+        }
+        Err(err) => {
+            panic!("\n - - - - - - - - - \n - - - - - - - - - Failed to connect to block service: {}", err);
+        }
+    }
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+
+    // Step 3: Create the OrderedBlockClient
+    println!("\n - - - - - - - - - \n - - - - - - - - - Step 3: Creating the OrderedBlockClient");
+    let client = OrderedBlockClient::new(ordered_block_store);
+
+    // Step 4: Insert some blocks into the OrderedBlockStore for testing
+    println!("\n - - - - - - - - - \n - - - - - - - - - Step 4: Inserting blocks into the OrderedBlockStore");
+    let epoch = 0;
+    let round = 1;
+    // This is a placeholder. You need to add code to insert ordered blocks as per your system's requirements.
+    let insert_success = client.insert_dummy_block(epoch, round).await;
+    if !insert_success {
+        panic!("\n - - - - - - - - - \n - - - - - - - - - Failed to insert dummy block for epoch {}, round {}", epoch, round);
+    }
+
+    // Step 5: Make a request to fetch the latest block using the client and assert the block was retrieved successfully
+    println!("\n - - - - - - - - - \n - - - - - - - - - Step 5: Fetching the latest block using the client");
+    let latest_block = client.get_block_by_round(epoch, round);
+    if let Some(block) = &latest_block {
+        assert_eq!(block["epoch"], epoch);
+        assert_eq!(block["round"], round);
+    } else {
+        panic!("\n - - - - - - - - - \n - - - - - - - - - Block not found");
+    }
+
+    // Step 6: Send a request to the REST API endpoint
+    let api_url = format!("http://127.0.0.1:3030/blocks/{}/{}", epoch, round);
+    let response = reqwest::get(&api_url).await.unwrap();
+    assert!(response.status().is_success());
+
+    let response_body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(response_body["epoch"], epoch);
+    assert_eq!(response_body["round"], round);
+}

--- a/consensus/src/consensus_observer/observer/block_service.rs
+++ b/consensus/src/consensus_observer/observer/block_service.rs
@@ -1,0 +1,179 @@
+use crate::consensus_observer::{
+    network::observer_message::OrderedBlock,
+    observer::ordered_blocks::OrderedBlockStore,
+};
+use serde::{Deserialize, Serialize};
+use warp::Filter; // Importing Warp to create an HTTP server and define API routes
+use async_std::task; // Importing async-std to run async code
+use tide::Request; // Importing Tide to create an HTTP server and define API routes
+
+// Client to interact with the ordered block store
+#[derive(Clone)]
+pub struct OrderedBlockClient {
+    ordered_block_store: OrderedBlockStore, // The internal ordered block store instance
+}
+
+impl OrderedBlockClient {
+    // Constructor to create a new instance of OrderedBlockClient
+    pub fn new(ordered_block_store: OrderedBlockStore) -> Self {
+        Self { ordered_block_store }
+    }
+
+    // Inserts dummy block into the ordered block store for testing
+    pub async fn insert_dummy_block(&self, epoch: u64, round: u64) -> bool {
+        let dummy_block = OrderedBlock::new_dummy(epoch, round);
+        let insertion_success = self.ordered_block_store.insert_ordered_block(dummy_block);
+        if !insertion_success {
+            eprintln!("Failed to insert dummy block for epoch {}, round {}", epoch, round);
+            return false;
+        }
+        true
+    }
+
+
+    // Method to retrieve a block by its epoch and round
+    pub fn get_block_by_round(&self, epoch: u64, round: u64) -> Option<serde_json::Value> {
+        // Fetch the ordered block from the store and serialize it into JSON format
+        self.ordered_block_store.get_ordered_block(epoch, round).map(|block| {
+            serde_json::json!({
+                "epoch": epoch,
+                "round": round,
+                "block_info": block.last_block().block_info(),
+            })
+        })
+    }
+
+    // Method to get the last ordered block
+    pub fn get_last_ordered_block(&self) -> Option<serde_json::Value> {
+        self.ordered_block_store.get_last_ordered_block().map(|block_info| {
+            serde_json::json!({
+                "epoch": block_info.epoch(),
+                "round": block_info.round(),
+                // Include other fields as necessary
+            })
+        })
+    }
+
+}
+
+// Handler for the GET request to fetch a block by epoch and round
+pub async fn get_block_handler_with_warp(
+    epoch: u64, 
+    round: u64, 
+    client: OrderedBlockClient
+) -> Result<impl warp::Reply, warp::Rejection> {
+    // Try to get the block using the OrderedBlockClient
+    if let Some(block) = client.get_block_by_round(epoch, round) {
+        // If block is found, return it as a JSON response
+        Ok(warp::reply::json(&block))
+    } else {
+        // If block is not found, return a 404 status with a JSON error message
+        Ok(warp::reply::json(&serde_json::json!({
+            "error": "Block not found",
+            "status": warp::http::StatusCode::NOT_FOUND.as_u16(),
+        })))
+    }
+}
+
+// Handler for the GET request to fetch a block by epoch and round
+async fn get_block_handler_with_tide(req: tide::Request<OrderedBlockClient>) -> tide::Result {
+    // Extract the parameters from the URL
+    let epoch: u64 = req.param("epoch")?.parse()?;
+    let round: u64 = req.param("round")?.parse()?;
+
+    // Use the OrderedBlockClient to get the block
+    let client = req.state();
+    if let Some(block) = client.get_block_by_round(epoch, round) {
+        let mut response = tide::Response::new(200);
+        response.set_body(tide::Body::from_json(&block)?);
+        Ok(response)
+    } else {
+        let mut response = tide::Response::new(404);
+        response.set_body(tide::Body::from_json(&serde_json::json!({"error": "Block not found"}))?);
+        Ok(response)
+    }
+}
+
+
+// pub async fn start_block_service(ordered_block_store: OrderedBlockStore) {
+//     println!("\n ................. \n ................ Starting block service...");
+
+//     // Create the OrderedBlockClient instance
+//     let ordered_block_client = OrderedBlockClient::new(ordered_block_store);
+
+//     // Clone the client to use it within Warp filters (needed for request handlers)
+//     let client_filter = warp::any().map(move || ordered_block_client.clone());
+
+//     // Define the API route for fetching a block by its epoch and round
+//     let get_block_by_round = warp::path!("blocks" / u64 / u64)
+//         .and(warp::get())
+//         .and(client_filter.clone())
+//         .and_then(get_block_handler);
+
+//     // Define a health check route
+//     let health_route = warp::path("health")
+//         .and(warp::get())
+//         .map(|| warp::reply::json(&serde_json::json!({ "status": "ok" })));
+
+//     // Combine the health route with other routes
+//     let routes = get_block_by_round.or(health_route);
+
+//     // Start the HTTP server on localhost:3030 with the defined routes
+//     task::block_on(async {
+//         warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+//     });
+// }
+
+
+
+pub async fn start_block_service_with_tide(ordered_block_store: OrderedBlockStore) {
+    println!("\n ................. \n ................ Starting block service...");
+
+    // Create the OrderedBlockClient instance
+    let ordered_block_client = OrderedBlockClient::new(ordered_block_store);
+
+    // Initialize a new tide server
+    let mut app = tide::with_state(ordered_block_client);
+
+    // Define the API route for fetching a block by its epoch and round
+    app.at("/blocks/:epoch/:round").get(get_block_handler_with_tide);
+
+    // Define a health check route
+    app.at("/health").get(|_| async {
+        let mut response = tide::Response::new(200);
+        response.set_body(tide::Body::from_json(&serde_json::json!({"status": "ok"}))?);
+        Ok(response)
+    });
+
+    // Start the HTTP server on localhost:3030
+    app.listen("127.0.0.1:3030").await.unwrap();
+}
+
+// Main function to start the block service server
+#[tokio::main]
+pub async fn start_block_service_with_tokio(ordered_block_store: OrderedBlockStore) {
+    println!("\n ................. \n ................ Starting block service...");
+
+    // Create the OrderedBlockClient instance
+    let ordered_block_client = OrderedBlockClient::new(ordered_block_store);
+
+    // Clone the client to use it within Warp filters (needed for request handlers)
+    let client_filter = warp::any().map(move || ordered_block_client.clone());
+
+    // Define the API route for fetching a block by its epoch and round
+    let get_block_by_round = warp::path!("blocks" / u64 / u64) // Matches the path "/blocks/{epoch}/{round}"
+        .and(warp::get()) // Matches only GET requests
+        .and(client_filter.clone()) // Pass the cloned OrderedBlockClient to the handler
+        .and_then(get_block_handler_with_warp); // Calls the handler function when the route is matched
+
+    // Define a health check route
+    let health_route = warp::path("health")
+        .and(warp::get())
+        .map(|| warp::reply::json(&serde_json::json!({ "status": "ok" })));
+
+    // Combine the health route with other routes
+    let routes = get_block_by_round.or(health_route);
+
+    // Start the HTTP server on localhost:3030 with the defined routes
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+}

--- a/consensus/src/consensus_observer/observer/mod.rs
+++ b/consensus/src/consensus_observer/observer/mod.rs
@@ -8,3 +8,4 @@ pub mod payload_store;
 pub mod pending_blocks;
 pub mod subscription;
 pub mod subscription_manager;
+pub mod block_service;

--- a/consensus/src/consensus_observer/observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/observer/ordered_blocks.rs
@@ -61,11 +61,11 @@ impl OrderedBlockStore {
             .get(&(epoch, round))
             .map(|(ordered_block, _)| ordered_block.clone())
     }
-
-    /// Inserts the given ordered block into the ordered blocks. This function
-    /// assumes the block has already been checked to extend the current ordered
-    /// blocks, and that the ordered proof has been verified.
-    pub fn insert_ordered_block(&self, ordered_block: OrderedBlock) {
+    
+    /// Inserts the given ordered block into the ordered blocks.
+    /// This function assumes the block has already been checked
+    /// to extend the current ordered blocks, and that the ordered proof has been verified.
+    pub fn insert_ordered_block(&self, ordered_block: OrderedBlock) -> bool {
         // Verify that the number of ordered blocks doesn't exceed the maximum
         let max_num_ordered_blocks = self.consensus_observer_config.max_num_pending_blocks as usize;
         if self.ordered_blocks.lock().len() >= max_num_ordered_blocks {
@@ -76,7 +76,7 @@ impl OrderedBlockStore {
                     ordered_block.proof_block_info()
                 ))
             );
-            return; // Drop the block if we've exceeded the maximum
+            return false; // Indicate failure to insert
         }
 
         // Otherwise, we can add the block to the ordered blocks
@@ -96,7 +96,10 @@ impl OrderedBlockStore {
         self.ordered_blocks
             .lock()
             .insert((last_block_epoch, last_block_round), (ordered_block, None));
+
+        true // Indicate successful insertion
     }
+
 
     /// Removes the ordered blocks for the given commit ledger info. This will
     /// remove all blocks up to (and including) the epoch and round of the commit.

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -64,6 +64,10 @@ mod transaction_filter;
 mod transaction_shuffler;
 mod txn_hash_and_authenticator_deduper;
 
+#[cfg(test)]
+mod block_service_test; // Add this line to include block_service_test.rs
+
+
 use aptos_metrics_core::IntGauge;
 pub use consensusdb::create_checkpoint;
 /// Required by the smoke tests

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,7 +14,9 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-api-types = { workspace = true }
 aptos-cached-packages = { workspace = true }
+aptos-consensus-types = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-global-constants = { workspace = true }
 aptos-ledger = { workspace = true }

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -19,6 +19,17 @@ This SDK provides all the necessary components for building on top of the Aptos 
 ## Installing Rust SDK
 Please refer to [Rust SDK Doc](https://aptos.dev/sdks/rust-sdk/) for details on how to install the Rust SDK.
 
+
+## Examples
+
+Examples are provided in the `examples` directory. To run the examples, use the following command:
+
+```bash
+cargo run --example <example_name>
+```
+
 ## License
 
 Aptos Core is licensed as [Apache 2.0](https://github.com/aptos-labs/aptos-core/blob/main/LICENSE).
+
+

--- a/sdk/examples/block_fetcher.rs
+++ b/sdk/examples/block_fetcher.rs
@@ -9,8 +9,10 @@
 // 4. The loop runs indefinitely, fetching and printing blocks as they become available.
 //
 // This script is designed to work with a local Aptos full node running on `http://0.0.0.0:8080/v1`.
-// In our tests the localnet was started with the following in the root of the repository.
+// In our tests the localnet was started first with the following command at the root of the repository.
 //      CARGO_NET_GIT_FETCH_WITH_CLI=true cargo run -p aptos-node -- --test
+// then use in the sdk directory
+//      cargo run --example block_fetcher
 
 
 use aptos_sdk::rest_client::Client;

--- a/sdk/examples/block_fetcher.rs
+++ b/sdk/examples/block_fetcher.rs
@@ -1,0 +1,65 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This example script connects to a locally running Aptos full node to fetch and print blocks starting from the genesis.
+// It performs the following steps:
+// 1. Initializes a REST client to interact with the Aptos full node using the URL specified in the `NODE_URL` variable.
+// 2. Starts fetching blocks from the genesis block (height 0) and prints their details, including block height, block ID, timestamp, and number of transactions.
+// 3. Continuously polls the blockchain for new blocks. If a block is not found (indicating no new blocks), it waits a short time before retrying.
+// 4. The loop runs indefinitely, fetching and printing blocks as they become available.
+//
+// This script is designed to work with a local Aptos full node running on `http://0.0.0.0:8080/v1`.
+// In our tests the localnet was started with the following in the root of the repository.
+//      CARGO_NET_GIT_FETCH_WITH_CLI=true cargo run -p aptos-node -- --test
+
+
+use aptos_sdk::rest_client::Client;
+// use aptos_consensus_types::block::Block;
+use aptos_api_types::Block;
+use once_cell::sync::Lazy;
+use std::{str::FromStr, time::Duration};
+use tokio::time::sleep;
+use url::Url;
+
+// Use the local full node URL
+static NODE_URL: Lazy<Url> = Lazy::new(|| {
+    Url::from_str("http://0.0.0.0:8080/v1")
+        .expect("Failed to parse node URL")
+});
+
+#[tokio::main]
+async fn main() {
+    let client = Client::new(NODE_URL.clone());
+
+    // Start from the genesis block height
+    let mut current_block_height = 0;
+
+    loop {
+        match client.get_block_by_height(current_block_height, true).await {
+            Ok(response) => {
+            // Print block details
+            let block: Block = response.into_inner();
+            println!("Block Height: {}", block.block_height);
+            println!("Block ID: {}", block.block_hash);
+            println!("Block Timestamp: {}", block.block_timestamp);
+            println!("First Version: {}", block.first_version);
+            println!("Last Version: {}", block.last_version);
+            println!("Number of Transactions: {}", block.transactions.as_ref().map_or(0, |txs| txs.len()));
+            println!("--------------------------");
+
+            // Move to the next block
+            current_block_height += 1;
+            }
+            Err(e) => {
+                // Handle the case where there are no new blocks
+                if e.to_string().contains("BlockNotFound") {
+                    // Wait for 250ms before retrying for a new block
+                    sleep(Duration::from_millis(250)).await;
+                } else {
+                    eprintln!("Error fetching block: {:?}", e);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/sdk/examples/transfer-coin.rs
+++ b/sdk/examples/transfer-coin.rs
@@ -1,6 +1,15 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// This Rust program uses the Aptos SDK to interact with the Aptos blockchain. It performs the following tasks:
+// 1. Initializes clients to connect to the Aptos blockchain node and faucet service using URLs from environment variables or defaults to devnet.
+// 2. Creates two local accounts: Alice and Bob.
+// 3. Funds Alice's account using the Aptos faucet service and creates Bob's account on-chain.
+// 4. Prints the initial balances of both accounts.
+// 5. Transfers a specified amount of coins from Alice to Bob, waits for the transaction to complete, and prints intermediate balances.
+// 6. Transfers more coins from Alice to Bob, waits for the transaction to complete, and prints the final balances.
+
+
 use anyhow::{Context, Result};
 use aptos_sdk::{
     coin_client::CoinClient,

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -29,6 +29,15 @@ impl ValidatorSigner {
         }
     }
 
+    /// Constructs a dummy signer with a random author and a private key generated from a fixed seed.
+    pub fn dummy() -> Self {
+        let zeroed_key = bls12381::PrivateKey::generate_for_testing();
+        Self::new(
+            AccountAddress::random(),
+            Arc::new(zeroed_key),
+        )
+    }
+
     /// Constructs a signature for `message` using `private_key`.
     pub fn sign<T: Serialize + CryptoHash>(
         &self,


### PR DESCRIPTION
## Description

Final goal: Reducing the repo to mempool and consensus only.


## Type of Change
- [x] Reduce dependencies in root Cargo to mempool and consensus (renamed to `Cargo_reduced_for_decseq.toml`)
- [x] Upgrade root Cargo to mempool and consensus
- [ ] Remove unused external crate dependencies
- [x] Added tests and code for client and server, see `/consensus/src/consensus_observer/observer/block_service` and `/consensus/src/block_service_test`
- [x] Added an example to continuously check for and if available fetch new blocks, in SDK/examples/block_fetcher`

## Which Components or Systems Does This Change Impact?
- [ ] All but mempool and consensus (and their dependencies)

## How Has This Been Tested?

- [x] Run `cargo test --tests` in `mempool` and `consensus`
- [ ] spam node
- [ ] Test if sequence can be extracted easily

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
<!--
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
-->
